### PR TITLE
Windows support, SSL/HTTPS by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ www/rotationz.nl
 www/grassland.test
 www/localhost/ddoc
 danode/server
+danode/server.exe
 server
+server.exe
 
 server.crt
 server.csr

--- a/README.md
+++ b/README.md
@@ -75,7 +75,15 @@ The content of the ./sh/run shell script:
     nohup authbind danode/server -k -b 100 -v 2 > server.log 2>&1 &
 
 This starts the server, does not allow for keyboard command (-k) has a backlog (-b) 
-of 100 simultaneous connection (per port), and produces more log output (-v 2)
+of 100 simultaneous connection (per port), and produces more log output (-v 2).
+
+          --port | -p          Port to listen on
+          --backlog | -b       Backlog of clients supported
+          --keyoff | -k        Keyboard on or off
+          --certDir            Location of SSL certificates
+          --keyFile            Server private key
+          --wwwRoot            Server www root folder
+          --verbose | -v       Verbose level (via commandline)
 
 ##### Example websites
 

--- a/README.md
+++ b/README.md
@@ -20,23 +20,47 @@ Download and compile the web server:
 
     git clone https://github.com/DannyArends/DaNode.git
     cd DaNode
+
+Build DaNode using the dub package manager:
+
+    dub build
+
+or, compile using the compile script:
+
     ./sh/compile
 
-To start the web server at a specific port (e.g. 8080) type:
+Then, start the web server at a specific port (e.g. 8080) type:
 
     ./danode/server -p 8080
 
 Confirm that the web server is running by going to: http://127.0.0.1:8080/
 
-To compile the server with https support (binds to port 443), use the following command:
+##### Create HTTPs support
+
+To compile the server with HTTPS support (binds to port 443), use the following command:
+
+    dub build --config=ssl --force
+
+or, compile using the compile script:
 
     ./sh/compile ssl
+
+Start the web server on port 80 and 443:
+
     ./danode/server
 
-Starting the server on port 80 and 443 might fail, when you do not have appropriate 
-rights on the system.
+Make sure to have rights to port 80 and 443, also you need a server private key and domain 
+certificates. I use Let's Encrypt to secure my own homepage. Setup instructions for Let's 
+Encrypt can be found at the [sh/letsEncrypt](sh/letsEncrypt) sh file
 
-To start the web server in deamon (background) mode at port 80, I use _nohup_ and _authbind_. 
+##### Troubleshooting: [ERROR]  unable to bind socket on port 80
+
+Starting the server on port 80 and 443 might fail, when you do not have appropriate 
+rights on the system. First check if you can start the server on another port:
+
+    ./danode/server -p 8080
+
+I use _nohup_ and _authbind_ to start the web server in deamon (background) mode at port 80, and 443 (SSL). 
 First, install _nohup_ and _authbind_ via your package manager, configure _authbind_ to allow 
 connections to port 80 (and 443, when using the ssl version), then start the webserver by running:
 
@@ -96,19 +120,13 @@ Then add the following lines to this hostfile using your favourite editor:
 Save the file with these lines added, then open a browser and navigate to: 
 http://www.domain.xxx, you should now see the content of your php / html file.
 
-##### Languages with web API supported
+##### Languages with supported API
 
      PHP, PYTHON, D, R
 
-###### webAPI's overview
+###### supported API overview
 
-             GET   POST    COOKIES     SERVER    FILE     CONFIG
-     PHP     V     V       V           V         V        V
-     PYTHON  V     V
-     D       V     V       V           V         V
-     R       V     V                   V         V
-
-For more information see: [api/README.md](api/README.md)
+See: [api/README.md](api/README.md)
 
 ##### Advanced config options
 
@@ -123,7 +141,16 @@ For more information see: [api/README.md](api/README.md)
    - Small files are buffered and served from memory
    - Stream large downloads using a flexible resizable buffer
 
-LICENCE
+##### Contributing
 
-(c) 2010-2014 Danny Arends
+Want to contribute? Great! Contribute to DaNode by starring or forking on Github, 
+and feel free to start an issue or sending a pull request.
+
+Fell free to also post comments on commits.
+
+Or be a maintainer, and adopt (the documentation of) a function.
+
+##### LICENCE
+
+(c) 2010-2016 Danny Arends
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then, start the web server at a specific port (e.g. 8080) type:
 
 Confirm that the web server is running by going to: http://127.0.0.1:8080/
 
-##### Create HTTPs support
+##### Enable HTTPs support
 
 To compile the server with HTTPS support (binds to port 443), use the following command:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ master: [![Build Status](https://travis-ci.org/DannyArends/DaNode.svg?branch=mas
 
 development: [![Build Status](https://travis-ci.org/DannyArends/DaNode.svg?branch=development)](https://travis-ci.org/DannyArends/DaNode)
 
-##### STRUCTURE
+##### Structure
 
 The DaNode server is designed to handle multiple websites independent and simultaneously. 
 The DaNode front-end routes incoming HTTP requests to the correct web folder. It allows 
@@ -14,7 +14,7 @@ Results from CGI scripts monitored and parsed back into the DaNode web server, (
 possible header errors, infinite execution of scripts) and results are send to the 
 requesting client via HTTP.
 
-##### GETTING DaNode
+##### Get DaNode
 
 Download and compile the web server:
 
@@ -77,14 +77,14 @@ The content of the ./sh/run shell script:
 This starts the server, does not allow for keyboard command (-k) has a backlog (-b) 
 of 100 simultaneous connection (per port), and produces more log output (-v 2)
 
-##### EXAMPLE WEBSITES
+##### Example websites
 
 See the [www/](www/) folder for a number of example web sites. After compiling the web 
 server, run the web server and the [www/localhost/](www/localhost/) folder is available 
 at http://localhost/ or http://127.0.0.1/ from the browser. For the other examples in 
 the [www/](www/) folder you will have to update your hosts file.
 
-##### CREATE A PHP ENABLED WEBSITE
+##### Create a PHP enabled website
 
 To create a simple PHP enabled web site first download and install DaNode, the next 
 step is to create a directory for the new website, by executing the following commands 
@@ -106,7 +106,7 @@ the index.php page:
     allowcgi     = yes
     redirecturl  = index.php
 
-###### UPDATE THE HOSTS FILE
+##### Update the hosts file
 
 If you do not own the domain name you want to host, use the /etc/hosts file to redirect 
 requests from the domain name to your local IP address using the hosts file:
@@ -121,24 +121,11 @@ Then add the following lines to this hostfile using your favourite editor:
 Save the file with these lines added, then open a browser and navigate to: 
 http://www.domain.xxx, you should now see the content of your php / html file.
 
-###### Supported API overview
+##### Supported back-end languages
 
 Languages with supported APIs: PHP, PYTHON, D, R
 
 See: [api/README.md](api/README.md)
-
-##### Advanced config options
-
-  - WEBSITE-CONFIG
-   - Sub-domain redirecting, such as http://www.test.nl to http://test.nl
-   - Directory browsing
-   - Custom index and error pages
-   - Executing different languages and the API
-   - Server overview page at http://127.0.0.1/
-
-  - FILEBUFFER
-   - Small files are buffered and served from memory
-   - Stream large downloads using a flexible resizable buffer
 
 ##### Contributing
 
@@ -149,7 +136,7 @@ Fell free to also post comments on commits.
 
 Or be a maintainer, and adopt (the documentation of) a function.
 
-##### LICENCE
+##### Licence
 
 (c) 2010-2016 Danny Arends
 

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ The content of the ./sh/run shell script:
 This starts the server, does not allow for keyboard command (-k) has a backlog (-b) 
 of 100 simultaneous connection (per port), and produces more log output (-v 2).
 
-          --port | -p          Port to listen on
-          --backlog | -b       Backlog of clients supported
-          --keyoff | -k        Keyboard on or off
-          --certDir            Location of SSL certificates
-          --keyFile            Server private key
-          --wwwRoot            Server www root folder
-          --verbose | -v       Verbose level (via commandline)
+          --port      -p       HTTP port to listen on (integer)
+          --backlog   -b       Backlog of clients supported simultaneously per port (integer)
+          --keyoff    -k       Keyboard input via STDIN (boolean)
+          --certDir            Location of folder with SSL certificates (string)
+          --keyFile            Server private key location (string)
+          --wwwRoot            Server www root folder holding website domains (string)
+          --verbose   -v       Verbose level, logs on STDOUT (integer)
 
 ##### Example websites
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Confirm that the web server is running by going to: http://127.0.0.1:8080/
 
 ##### Enable HTTPs support
 
-To compile the server with HTTPS support (binds to port 443), use the following command:
+To compile the server with HTTPS support (binds to port 443), use the dub sll configuration:
 
-    dub build --config=ssl --force
+    dub build --config=ssl
 
 or, compile using the compile script:
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Start the web server on port 80 and 443:
 
     ./danode/server
 
-Make sure to have rights to port 80 and 443, also you need a server private key and domain 
-certificates. I use Let's Encrypt to secure my own homepage. Setup instructions for Let's 
-Encrypt can be found at the [sh/letsEncrypt](sh/letsEncrypt) sh file
+After starting the server, confirm that the web server is running by going to http://127.0.0.1/ 
+and https://127.0.0.1/ and make sure you have enough user rights to bind port 80 and 443, a server 
+private key and domain certificates are required. I use Let's Encrypt to secure my own homepage. 
+Setup instructions for Let's Encrypt can be found in the [sh/letsEncrypt](sh/letsEncrypt) file.
 
 ##### Troubleshooting: [ERROR]  unable to bind socket on port 80
 
@@ -67,15 +68,14 @@ connections to port 80 (and 443, when using the ssl version), then start the web
 
     ./sh/run
 
+##### Command-line parameters
+
 The content of the ./sh/run shell script:
 
     nohup authbind danode/server -k -b 100 -v 2 > server.log 2>&1 &
 
 This starts the server, does not allow for keyboard command (-k) has a backlog (-b) 
 of 100 simultaneous connection (per port), and produces more log output (-v 2)
-
-After starting the server, confirm that the web server is running by going 
-to http://127.0.0.1/ and https://127.0.0.1/
 
 ##### EXAMPLE WEBSITES
 

--- a/README.md
+++ b/README.md
@@ -121,12 +121,9 @@ Then add the following lines to this hostfile using your favourite editor:
 Save the file with these lines added, then open a browser and navigate to: 
 http://www.domain.xxx, you should now see the content of your php / html file.
 
-##### Languages with supported API
+###### Supported API overview
 
-     PHP, PYTHON, D, R
-
-
-###### supported API overview
+Languages with supported APIs: PHP, PYTHON, D, R
 
 See: [api/README.md](api/README.md)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Confirm that the web server is running by going to: http://127.0.0.1:8080/
 
 ##### Enable HTTPs support
 
-To compile the server with HTTPS support (binds to port 443), use the dub sll configuration:
+To compile the server with HTTPS support (binds to port 443), use dub and specify 
+the _ssl_ configuration:
 
     dub build --config=ssl
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ http://www.domain.xxx, you should now see the content of your php / html file.
 
      PHP, PYTHON, D, R
 
+
 ###### supported API overview
 
 See: [api/README.md](api/README.md)

--- a/danode/client.d
+++ b/danode/client.d
@@ -35,7 +35,7 @@ abstract class DriverInterface {
     long[long]          senddata;            /// Size of data send per request
     SysTime             starttime;           /// Time in ms since this process came alive
     SysTime             modtime;             /// Time in ms since this process was last modified
-    Address             address;             /// Private  address field
+    Address             address;             /// Private address field
 
     long receive(Socket conn, long maxsize = 4096);
     void send(ref Response response, Socket conn, long maxsize = 4096);
@@ -129,13 +129,13 @@ class Client : Thread, ClientInterface {
 class HTTP : DriverInterface {
   public:
     this(Socket socket, bool blocking = false){ // writefln("[HTTP]   driver constructor");
-      this.socket           = socket;
-      this.socket.blocking  = blocking;
-      this.starttime        = Clock.currTime();           /// Time in ms since this process came alive
-      this.modtime          = Clock.currTime();           /// Time in ms since this process was modified
-      try{
+      this.socket = socket;
+      this.socket.blocking = blocking;
+      this.starttime = Clock.currTime();           /// Time in ms since this process came alive
+      this.modtime = Clock.currTime();           /// Time in ms since this process was modified
+      try {
         this.address        = socket.remoteAddress();
-      } catch(Exception e){
+      } catch(Exception e) {
         writefln("[WARN]   unable to resolve requesting origin");
       }
     }
@@ -143,6 +143,7 @@ class HTTP : DriverInterface {
     override long receive(Socket socket, long maxsize = 4096) {
       long received;
       char[] tmpbuffer = new char[](maxsize);
+      if(!socket.isAlive()) return(-1);
       if((received = socket.receive(tmpbuffer)) > 0) {
         inbuffer.put(tmpbuffer[0 .. received]); modtime = Clock.currTime();
       }
@@ -151,6 +152,7 @@ class HTTP : DriverInterface {
     }
 
     override void send(ref Response response, Socket socket, long maxsize = 4096) {
+      if(!socket.isAlive()) return;
       long send = socket.send(response.bytes(maxsize));
       if(send >= 0) {
         response.index += send; modtime = Clock.currTime(); senddata[requests] += send;

--- a/danode/client.d
+++ b/danode/client.d
@@ -65,7 +65,7 @@ class Client : Thread, ClientInterface {
         while(running && modified < maxtime){
           if(driver.receive(driver.socket) > 0){                                                // We've received new data
             if(!response.ready){                                                                // If we're not ready to respond yet
-              router.route(ip(), port(), request, response, to!string(driver.inbuffer.data));   // Parse the data and try to create a response (Could fail multiple times)
+              router.route(ip(), port(), request, response, to!string(driver.inbuffer.data), driver.isSecure());   // Parse the data and try to create a response (Could fail multiple times)
             }
             if(response.ready && !response.completed){                                        // We know what to respond, but haven't send all of it yet
               driver.send(response, driver.socket);                                           // Send the response, hit multiple times, send what you can and return

--- a/danode/client.d
+++ b/danode/client.d
@@ -37,7 +37,7 @@ abstract class DriverInterface {
     SysTime             modtime;             /// Time in ms since this process was last modified
     Address             address;             /// Private address field
 
-    long receive(Socket conn, long maxsize = 4096);
+    ptrdiff_t receive(Socket conn, ptrdiff_t maxsize = 4096);
     void send(ref Response response, Socket conn, long maxsize = 4096);
     bool isSecure();
 }
@@ -140,8 +140,8 @@ class HTTP : DriverInterface {
       }
     }
 
-    override long receive(Socket socket, long maxsize = 4096) {
-      long received;
+    override ptrdiff_t receive(Socket socket, ptrdiff_t maxsize = 4096) {
+      ptrdiff_t received;
       char[] tmpbuffer = new char[](maxsize);
       if(!socket.isAlive()) return(-1);
       if((received = socket.receive(tmpbuffer)) > 0) {

--- a/danode/client.d
+++ b/danode/client.d
@@ -38,7 +38,7 @@ abstract class DriverInterface {
     Address             address;             /// Private address field
 
     ptrdiff_t receive(Socket conn, ptrdiff_t maxsize = 4096);
-    void send(ref Response response, Socket conn, long maxsize = 4096);
+    void send(ref Response response, Socket conn, ptrdiff_t maxsize = 4096);
     bool isSecure();
 }
 
@@ -151,9 +151,9 @@ class HTTP : DriverInterface {
       return(inbuffer.data.length);
     }
 
-    override void send(ref Response response, Socket socket, long maxsize = 4096) {
+    override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096) {
       if(!socket.isAlive()) return;
-      long send = socket.send(response.bytes(maxsize));
+      ptrdiff_t send = socket.send(response.bytes(maxsize));
       if(send >= 0) {
         response.index += send; modtime = Clock.currTime(); senddata[requests] += send;
         if(response.index >= response.length) response.completed = true;

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -110,7 +110,8 @@ class FileSystem {
     final Domain scan(string dname){ synchronized {
       Domain domain;
       foreach (DirEntry f; dirEntries(dname, SpanMode.depth)){ if(f.isFile()){
-        string shortname = f.name[dname.length .. $];
+        string shortname = replace(f.name[dname.length .. $], "\\", "/");
+        writefln("File: %s -> %s", f.name, shortname);
         if(!domain.files.has(shortname)){
           domain.files[shortname] = new FileInfo(f.name);
           domain.entries++;
@@ -125,6 +126,7 @@ class FileSystem {
     final string localroot(string hostname) const { return(format("%s%s",this.root, hostname)); }
 
     final FileInfo file(string localroot, string path, int verbose = NORMAL){ synchronized {
+      writeln(domains[localroot].files);
       if(!domains[localroot].files.has(path) && exists(format("%s%s", localroot, path))){
         if(logger.verbose >= INFO) writefln("[FILES]  new file %s, rescanning index: %s", path, localroot);
         domains[localroot] = scan(localroot);

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -53,12 +53,12 @@ class FileInfo : Payload {
     final @property SysTime       mtime() const { if(!realfile){ return btime; } return path.timeLastModified(); }
     final @property long          ready() { return(true); }
     final @property PayLoadType   type() const { return(PayLoadType.Message); }
-    final @property long          length() const { if(!realfile){ return 0; } return cast(long)(path.getSize()); }
+    final @property ptrdiff_t     length() const { if(!realfile){ return 0; } return to!ptrdiff_t(path.getSize()); }
     final @property long          buffersize() const { return cast(long)(buf.length); }
     final @property string        mimetype() const { return mime(path); }
     final @property StatusCode    statuscode() const { return StatusCode.Ok; }
 
-    final char[] bytes(long from, long maxsize = 1024){ synchronized {
+    final char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024){ synchronized {
       if(!realfile){ return []; }
       if(needsupdate) buffer();
       if(!buffered){
@@ -71,7 +71,7 @@ class FileInfo : Payload {
         }catch(Exception e){ writefln("[WARN]   exception %s while streaming file: %s", e.msg, path); }
         return(slice);
       }else if(from < buf.length){
-        return(cast(char[]) buf[from .. cast(ulong)fmin(from+maxsize, $)]);
+        return(cast(char[]) buf[from .. to!ptrdiff_t(fmin(from+maxsize, $))]);
       }
       return([]);
     } }

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -111,15 +111,17 @@ class FileSystem {
       Domain domain;
       foreach (DirEntry f; dirEntries(dname, SpanMode.depth)){ if(f.isFile()){
         string shortname = replace(f.name[dname.length .. $], "\\", "/");
-        writefln("[SCAN]   File: %s -> %s", f.name, shortname);
+        if(logger.verbose >= INFO) writefln("[SCAN]   File: %s -> %s", f.name, shortname);
         if(!domain.files.has(shortname)){
           domain.files[shortname] = new FileInfo(f.name);
           domain.entries++;
           if(domain.files[shortname].buffer(maxsize, logger.verbose)) domain.buffered++;
         }
       } }
-      if(logger.verbose >= INFO)
-        writefln("[INFO]   domain: %s, files %s|%s, size: %.2f/%.2f kB", dname, domain.buffered, domain.entries, domain.buffersize/1024.0, domain.size/1024.0);
+      if(logger.verbose >= INFO) {
+        writef("[INFO]   domain: %s, files %s|%s", dname, domain.buffered, domain.entries);
+        writefln(", size: %.2f/%.2f kB", domain.buffersize/1024.0, domain.size/1024.0);
+      }
       return(domain);
     } }
 

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -19,11 +19,11 @@ interface Payload {
     @property long                ready();
     @property StatusCode          statuscode() const;
     @property PayLoadType         type() const;
-    @property long                length() const;
+    @property ptrdiff_t           length() const;
     @property SysTime             mtime();
     @property string              mimetype() const;
 
-    const(char)[] bytes(ptrdiff_t from, long maxsize = 1024);
+    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024);
 }
 
 class CGI : Payload {
@@ -35,8 +35,8 @@ class CGI : Payload {
 
     final @property PayLoadType   type() const { return(PayLoadType.Script); }
     final @property long          ready() { return(external.finished); }
-    final @property long          length() const { 
-      if(!external.running) return(getHeader!long("Content-Length", external.length));
+    final @property ptrdiff_t     length() const { 
+      if(!external.running) return(getHeader!ptrdiff_t("Content-Length", to!ptrdiff_t(external.length)));
       return -1; 
     }
     final @property SysTime       mtime() { return Clock.currTime(); }
@@ -72,7 +72,7 @@ class CGI : Payload {
       return(to!StatusCode(to!int(status)));
     }
 
-    const(char)[] bytes(ptrdiff_t from, long maxsize = 1024){ return(external.output(from)[0 .. to!ptrdiff_t(fmin(from+maxsize, $))]); }
+    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024){ return(external.output(from)[0 .. to!ptrdiff_t(fmin(from+maxsize, $))]); }
 
     final ptrdiff_t endOfHeader() const {
       string outputSoFar = to!string(external.output(0));
@@ -93,12 +93,12 @@ class Message : Payload {
     this(StatusCode status, string message, string mime = "text/plain"){ this.status = status; this.message = message; this.mime = mime; }
 
     final @property PayLoadType   type() const { return(PayLoadType.Message); }
-    final @property long      ready() { return(true); }
-    final @property long      length() const { return(message.length); }
-    final @property SysTime   mtime() { return Clock.currTime(); }
-    final @property string    mimetype() const { return mime; }
-    final @property StatusCode statuscode() const { return status; }
-    char[] bytes(ptrdiff_t from, long maxsize = 1024){ return(cast(char[])message[from .. to!ptrdiff_t(fmin(from+maxsize, $))]); }
+    final @property long          ready() { return(true); }
+    final @property ptrdiff_t     length() const { return(message.length); }
+    final @property SysTime       mtime() { return Clock.currTime(); }
+    final @property string        mimetype() const { return mime; }
+    final @property StatusCode    statuscode() const { return status; }
+    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024){ return(cast(char[])message[from .. to!ptrdiff_t(fmin(from+maxsize, $))]); }
 }
 
 class Empty : Message {

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -98,7 +98,7 @@ class Message : Payload {
     final @property SysTime       mtime() { return Clock.currTime(); }
     final @property string        mimetype() const { return mime; }
     final @property StatusCode    statuscode() const { return status; }
-    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024){ return(cast(char[])message[from .. to!ptrdiff_t(fmin(from+maxsize, $))]); }
+    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024){ return( message[from .. to!ptrdiff_t(fmin(from+maxsize, $))].dup ); }
 }
 
 class Empty : Message {

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -42,7 +42,7 @@ class CGI : Payload {
     final @property SysTime       mtime() { return Clock.currTime(); }
     final @property string        mimetype() const { return "text/html"; } // Todo if there is a header parse it out of there
 
-    final T getHeader(T)(string key, T def = T.init, long i = 1) const {
+    final T getHeader(T)(string key, T def = T.init, ptrdiff_t i = 1) const {
       if(endOfHeader > 0){
         foreach(line; to!string(external.output(0))[0..endOfHeader()].split("\n")){
           string[] elems = line.split(": ");
@@ -72,11 +72,11 @@ class CGI : Payload {
       return(to!StatusCode(to!int(status)));
     }
 
-    const(char)[] bytes(long from, long maxsize = 1024){ return(external.output(from)[0 .. to!long(fmin(from+maxsize, $))]); }
+    const(char)[] bytes(ptrdiff_t from, long maxsize = 1024){ return(external.output(from)[0 .. to!ptrdiff_t(fmin(from+maxsize, $))]); }
 
-    final long endOfHeader() const {
+    final ptrdiff_t endOfHeader() const {
       string outputSoFar = to!string(external.output(0));
-      long idx = outputSoFar.indexOf("\r\n\r\n");
+      ptrdiff_t idx = outputSoFar.indexOf("\r\n\r\n");
       if(idx <= 0) idx = outputSoFar.indexOf("\n\n");
       return(idx);
     }
@@ -98,7 +98,7 @@ class Message : Payload {
     final @property SysTime   mtime() { return Clock.currTime(); }
     final @property string    mimetype() const { return mime; }
     final @property StatusCode statuscode() const { return status; }
-    char[] bytes(long from, long maxsize = 1024){ return(cast(char[])message[from .. cast(ulong)fmin(from+maxsize, $)]); }
+    char[] bytes(ptrdiff_t from, long maxsize = 1024){ return(cast(char[])message[from .. to!ptrdiff_t(fmin(from+maxsize, $))]); }
 }
 
 class Empty : Message {

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -23,7 +23,7 @@ interface Payload {
     @property SysTime             mtime();
     @property string              mimetype() const;
 
-    const(char)[] bytes(long from, long maxsize = 1024);
+    const(char)[] bytes(ptrdiff_t from, long maxsize = 1024);
 }
 
 class CGI : Payload {

--- a/danode/process.d
+++ b/danode/process.d
@@ -19,15 +19,15 @@ struct WaitResult {
   int status;                // Exit status when terminated
 }
 
-int readpipe(ref Pipe pipe){
+int readpipe(ref Pipe pipe, int verbose = NORMAL){
   File fp = pipe.readEnd;
   try{
     if(fp.isOpen()){
-      if(!nonblocking(fp)) writeln("[WARN]   unable to create nonblocking pipe for command");
+      if(!nonblocking(fp) && verbose >= DEBUG) writeln("[WARN]   unable to create nonblocking pipe for command");
       return(fgetc(fp.getFP()));
     }
   }catch(Exception e){
-    writefln("[WARN]   exception during readpipe command");
+    writefln("[WARN]   Exception during readpipe command: %s", e.msg);
     fp.close();
   }
   return(EOF);

--- a/danode/process.d
+++ b/danode/process.d
@@ -14,7 +14,6 @@ version(Posix) {
   import core.sys.posix.fcntl : fcntl, F_SETFL, O_NONBLOCK;
 }
 
-
 struct WaitResult {
   bool terminated;           // Is the process terminated
   int status;                // Exit status when terminated
@@ -75,7 +74,7 @@ class Process : Thread {
     }
 
      // Output/Errors so far
-    final @property const(char)[] output(long from) const { 
+    final @property const(char)[] output(ptrdiff_t from) const { 
       synchronized { if(errbuffer.data.length == 1){ return(outbuffer.data[from .. $]); } return errbuffer.data[from .. $]; }
     }
 

--- a/danode/process.d
+++ b/danode/process.d
@@ -34,8 +34,12 @@ int readpipe(ref Pipe pipe){
   return(EOF);
 }
 
-bool nonblocking(ref File file){
- return(fcntl(fileno(file.getFP()), F_SETFL, O_NONBLOCK) != -1); 
+bool nonblocking(ref File file) {
+  version(Posix) {
+    return(fcntl(fileno(file.getFP()), F_SETFL, O_NONBLOCK) != -1); 
+  }else{
+    return(false);
+  }
 }
 
 class Process : Thread {

--- a/danode/request.d
+++ b/danode/request.d
@@ -74,13 +74,13 @@ struct Request {
   final void update(in string content){ this.content = content; }
 
   final @property string host() const { 
-    long i = headers.from("Host").indexOf(":");
+    ptrdiff_t i = headers.from("Host").indexOf(":");
     if(i > 0) return(headers.from("Host")[0 .. i]);
     return(headers.from("Host")); 
   }
 
   final @property ushort serverport() const {
-    long i = headers.from("Host").indexOf(":");
+    ptrdiff_t i = headers.from("Host").indexOf(":");
     if(i > 0){ return( to!ushort(headers.from("Host")[(i+1) .. $])); } 
     return(to!ushort(80));
   }
@@ -99,9 +99,9 @@ struct Request {
     return params;
   }
 
-  final @property string    path() const { long i = url.indexOf("?"); if(i > 0){ return(url[0 .. i]); }else{ return(url); } }
-  final @property string    query() const { long i = uri.indexOf("?"); if(i > 0){ return(uri[i .. $]); }else{ return("?"); } }
-  final @property string    uripath() const { long i = uri.indexOf("?"); if(i > 0){ return(uri[0 .. i]); }else{ return(uri); } }
+  final @property string    path() const { ptrdiff_t i = url.indexOf("?"); if(i > 0){ return(url[0 .. i]); }else{ return(url); } }
+  final @property string    query() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[i .. $]); }else{ return("?"); } }
+  final @property string    uripath() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[0 .. i]); }else{ return(uri); } }
   final @property bool      keepalive() const { return( toLower(headers.from("Connection")) == "keep-alive"); }
   final @property SysTime   ifModified() const { return(parseHtmlDate(headers.from("If-Modified-Since"))); }
   final @property bool      track() const { return(  headers.from("DNT","0") == "0"); }

--- a/danode/request.d
+++ b/danode/request.d
@@ -14,7 +14,7 @@ import std.regex : regex, match;
 import danode.functions : interpreter, from, toD, mtoI;
 import danode.webconfig : WebConfig;
 import danode.post : PostItem, PostType;
-import danode.log : INFO, DEBUG;
+import danode.log;
 
 SysTime parseHtmlDate(const string datestr){ // 21 Apr 2014 20:20:13 CET
   SysTime ts =  SysTime(DateTime(-7, 1, 1, 1, 0, 0));
@@ -40,10 +40,11 @@ struct Request {
   SysTime           starttime;
   string            content;
   PostItem[string]  postinfo;
+  bool              isSecure;
   int               verbose;
 
-  final void parse(in string ip, long port, in string header, in string content, int verbose){
-    this.ip  = ip; this.port = port; this.content = content;
+  final void parse(in string ip, long port, in string header, in string content, bool isSecure = false, int verbose = NORMAL){
+    this.ip  = ip; this.port = port; this.content = content; this.isSecure = isSecure;
     this.setHeader(header);
     this.starttime = Clock.currTime();
     this.requestid = md5UUID(format("%s:%d-%s", ip, port, starttime));

--- a/danode/response.d
+++ b/danode/response.d
@@ -72,7 +72,7 @@ struct Response {
   @property final StatusCode statuscode() const { return payload.statuscode; }
   @property final bool keepalive() const { return( toLower(connection) == "keep-alive"); }
   @property final long length(){ if(payload.length >= 0){ return header.length + payload.length; }else{ return(long.max); } }
-  @property final const(char)[] bytes(in long maxsize = 1024){                              // Return the bytes from index to the end
+  @property final const(char)[] bytes(in ptrdiff_t maxsize = 1024){                              // Return the bytes from index to the end
     ptrdiff_t hsize = header.length;
     if(index <= hsize) return(header[index .. hsize] ~ payload.bytes(0, maxsize-hsize));    // We haven't completed the header yet
     return(payload.bytes(index-hsize));                                                     // Header completed, just stream bytes from the payload

--- a/danode/response.d
+++ b/danode/response.d
@@ -91,10 +91,11 @@ Response create(in Request request, in StatusCode statuscode = StatusCode.Ok, in
   return(response);
 }
 
-void redirect(ref Response response, in Request request, in string fqdn, int verbose) {
+void redirect(ref Response response, in Request request, in string fqdn, bool isSecure = false, int verbose = NORMAL) {
   if(verbose >= DEBUG) writefln("[DEBUG]  redirecting request to %s", fqdn);
   response.payload = new Empty(StatusCode.MovedPermanently);
-  response.customheader("Location", format("http://%s:%d%s%s", fqdn, request.serverport, request.path, request.query));
+  response.customheader("Location", format("http%s://%s%s%s", isSecure? "s": "", fqdn, request.path, request.query));
+  response.connection = "Close";
   response.ready = true;
 }
 

--- a/danode/response.d
+++ b/danode/response.d
@@ -32,7 +32,7 @@ struct Response {
   bool              routed       = false;
   bool              completed    = false;
   Appender!(char[]) hdr;
-  long              index        = 0;
+  ptrdiff_t         index        = 0;
 
   final void customheader(string key, string value){ headers[key] = value; }
 
@@ -72,8 +72,8 @@ struct Response {
   @property final StatusCode statuscode() const { return payload.statuscode; }
   @property final bool keepalive() const { return( toLower(connection) == "keep-alive"); }
   @property final long length(){ if(payload.length >= 0){ return header.length + payload.length; }else{ return(long.max); } }
-  @property final const(char)[] bytes(in long maxsize = 1024){                                     // Return the bytes from index to the end
-    long hsize = header.length;
+  @property final const(char)[] bytes(in long maxsize = 1024){                              // Return the bytes from index to the end
+    ptrdiff_t hsize = header.length;
     if(index <= hsize) return(header[index .. hsize] ~ payload.bytes(0, maxsize-hsize));    // We haven't completed the header yet
     return(payload.bytes(index-hsize));                                                     // Header completed, just stream bytes from the payload
   }

--- a/danode/router.d
+++ b/danode/router.d
@@ -7,7 +7,7 @@ import std.string : indexOf;
 import danode.client : ClientInterface;
 import danode.httpstatus : StatusCode;
 import danode.request : Request;
-import danode.response : SERVERINFO, Response, redirect, create, notmodified, domainNotFound, serveCGI, serveStaticFile, serveDirectory, serveForbidden, notFound;
+import danode.response;
 import danode.webconfig : WebConfig;
 import danode.payload : Message, CGI;
 import danode.mimetypes : mime;
@@ -15,6 +15,9 @@ import danode.functions : from, has, isCGI, isFILE, isDIR, Msecs, htmltime, brow
 import danode.filesystem : FileSystem, FileInfo;
 import danode.post : parsepost, PostType, servervariables;
 import danode.log;
+version(SSL) {
+  import danode.ssl : hasCertificate;
+}
 
 class Router {
   private:
@@ -31,12 +34,12 @@ class Router {
       logger.write(client, request, response);
     }
 
-    final bool parse(in string ip, long port, ref Request request, ref Response response, in string inputSoFar) const {
+    final bool parse(in string ip, long port, ref Request request, ref Response response, in string inputSoFar, bool isSecure) const {
       ptrdiff_t idx = inputSoFar.indexOf("\r\n\r\n");
       if(idx <= 0) idx = inputSoFar.indexOf("\n\n");
       if(idx <= 0) return(false);
       if(!response.created) {
-        request.parse(ip, port, inputSoFar[0 .. idx], inputSoFar[(idx + 4) .. $], logger.verbose);
+        request.parse(ip, port, inputSoFar[0 .. idx], inputSoFar[(idx + 4) .. $], isSecure, logger.verbose);
         response = request.create();
       } else {
         request.update(inputSoFar[(idx + 4) .. $]);
@@ -44,8 +47,8 @@ class Router {
       return(true);
     }
 
-    final void route(in string ip, long port, ref Request request, ref Response response, in string inputSoFar) {
-      if(!response.routed && parse(ip, port, request, response, inputSoFar)) {
+    final void route(in string ip, long port, ref Request request, ref Response response, in string inputSoFar, bool isSecure) {
+      if(!response.routed && parse(ip, port, request, response, inputSoFar, isSecure)) {
         if(parsepost(request, response, filesystem, logger.verbose)) {
           route(request, response);
         }
@@ -55,7 +58,7 @@ class Router {
     final void route(ref Request request, ref Response response, bool finalrewrite = false) {
       string localroot = filesystem.localroot(request.shorthost());
 
-      if(logger.verbose >= DEBUG){
+      if(logger.verbose >= DEBUG) {
         writefln("[DEBUG]  %s client %s:%s", (finalrewrite? "redirecting" : "routing"), request.ip, request.port);
         writefln("[INFO]   shorthost -> localroot: %s -> %s", request.shorthost(), localroot);
       }
@@ -72,7 +75,9 @@ class Router {
         writefln("[DEBUG]  request.host: %s, fqdn: %s", request.host, fqdn);
         writefln("[DEBUG]  localpath: %s, exists ? %s", localpath, localpath.exists());
       }
-      if(request.host != fqdn) return response.redirect(request, fqdn, logger.verbose);  // Requested the wrong shortdomain
+      if(request.host != fqdn || request.isSecure != hasCertificate(fqdn)) {
+        return response.redirect(request, fqdn, hasCertificate(fqdn), logger.verbose);  // Requested the wrong shortdomain
+      }
 
       if(localpath.exists()) {  // Requested an existing resource
         if(localpath.isCGI() && config.allowcgi)

--- a/danode/router.d
+++ b/danode/router.d
@@ -32,7 +32,7 @@ class Router {
     }
 
     final bool parse(in string ip, long port, ref Request request, ref Response response, in string inputSoFar) const {
-      long idx = inputSoFar.indexOf("\r\n\r\n");
+      ptrdiff_t idx = inputSoFar.indexOf("\r\n\r\n");
       if(idx <= 0) idx = inputSoFar.indexOf("\n\n");
       if(idx <= 0) return(false);
       if(!response.created) {

--- a/danode/router.d
+++ b/danode/router.d
@@ -22,9 +22,9 @@ class Router {
     Log             logger;
 
   public:
-    this(int verbose = NORMAL){
+    this(string wwwRoot = "./www/", int verbose = NORMAL){
       this.logger = new Log(verbose);
-      this.filesystem = new FileSystem(logger);
+      this.filesystem = new FileSystem(logger, wwwRoot);
     }
 
     void logrequest(in ClientInterface client, in Request request, in Response response) {

--- a/danode/server.d
+++ b/danode/server.d
@@ -13,8 +13,7 @@ import danode.client : DriverInterface, Client, HTTP;
 import danode.router : Router;
 import danode.log;
 import danode.serverconfig : ServerConfig;
-version(SSL){
-  import deimos.openssl.ssl;
+version(SSL) {
   import danode.ssl : HTTPS, initSSL, closeSSL;
 }
 import std.getopt : getopt;

--- a/danode/server.d
+++ b/danode/server.d
@@ -32,9 +32,9 @@ class Server : Thread {
     }
 
   public:
-    this(ushort port = 80, int backlog = 100, int verbose = NORMAL) {
+    this(ushort port = 80, int backlog = 100, string wwwRoot = "./www/", int verbose = NORMAL) {
       this.starttime = Clock.currTime();            // Start the timer
-      this.router = new Router(verbose);            // Start the router
+      this.router = new Router(wwwRoot, verbose);   // Start the router
       this.socket = initialize(port, backlog);      // Create the HTTP socket
       version(SSL) {
         this.sslsocket = initialize(443, backlog);  // Create the SSL / HTTPs socket
@@ -151,7 +151,7 @@ void main(string[] args) {
   version(unittest){
     // Do nothing, unittests will run
   }else{
-    auto server = new Server(port, backlog, verbose);
+    auto server = new Server(port, backlog, wwwRoot, verbose);
     version(SSL) {
       server.initSSL(certDir, keyFile);  // Load SSL certificates, using the server key
     }

--- a/danode/server.d
+++ b/danode/server.d
@@ -38,7 +38,6 @@ class Server : Thread {
       this.socket = initialize(port, backlog);      // Create the HTTP socket
       version(SSL) {
         this.sslsocket = initialize(443, backlog);  // Create the SSL / HTTPs socket
-        initSSL(this);                              // Initialize the SSL certificates
         backlog = (backlog * 2) + 1;                // Enlarge the backlog, for N clients and 1 ssl server socket
       }
       backlog = backlog + 1;                        // Add room for the server socket
@@ -139,14 +138,23 @@ void main(string[] args) {
   int    backlog  = 100;
   int    verbose  = NORMAL;
   bool   keyoff   = false;
+  string certDir  = ".ssl/";
+  string keyFile  = ".ssl/server.key";
+  string wwwRoot  = "www";
   getopt(args, "port|p",     &port,         // Port to listen on
                "backlog|b",  &backlog,      // Backlog of clients supported
                "keyoff|k",   &keyoff,       // Keyboard on or off
+               "certDir",    &certDir,      // Location of SSL certificates
+               "keyFile",    &keyFile,      // Server private key
+               "wwwRoot",    &wwwRoot,      // Server www root folder
                "verbose|v",  &verbose);     // Verbose level (via commandline)
   version(unittest){
     // Do nothing, unittests will run
   }else{
     auto server = new Server(port, backlog, verbose);
+    version(SSL) {
+      server.initSSL(certDir, keyFile);  // Load SSL certificates, using the server key
+    }
     server.start();
     version(Windows) {
       writeln("[WARN]   -k has been set to true, we cannot handle keyboard input under windows at the moment");

--- a/danode/server.d
+++ b/danode/server.d
@@ -140,7 +140,7 @@ void main(string[] args) {
   bool   keyoff   = false;
   string certDir  = ".ssl/";
   string keyFile  = ".ssl/server.key";
-  string wwwRoot  = "www";
+  string wwwRoot  = "./www/";
   getopt(args, "port|p",     &port,         // Port to listen on
                "backlog|b",  &backlog,      // Backlog of clients supported
                "keyoff|k",   &keyoff,       // Keyboard on or off

--- a/danode/server.d
+++ b/danode/server.d
@@ -122,7 +122,7 @@ class Server : Thread {
       }
       socket.close();
       version(SSL) {
-        closeSSL(sslsocket);
+        sslsocket.closeSSL();
       }
     }
 }
@@ -150,7 +150,7 @@ void main(string[] args) {
         if(line.startsWith("verbose")) server.verbose(line);
       }
       fflush(stdout);
-      Thread.sleep(dur!"msecs"(2));
+      Thread.sleep(dur!"msecs"(250));
     }
     writefln("[INFO]   Server shutting down: %d", server.running);
     server.info();

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -117,6 +117,20 @@ version(SSL){
     return ctx;
   }
 
+  bool hasCertificate(string hostname) {
+    writefln("[HTTPS]  '%s' certificate?", hostname);
+    string s;
+    for(size_t x = 0; x < ncontext; x++) {
+      s = to!string(contexts[x].hostname.ptr);
+      writefln("[HTTPS]  context: %s %s", hostname, s);
+      if(hostname.endsWith(s)) {
+        writefln("[HTTPS]  Switching SSL context to %s", hostname);
+        return true;
+      }
+    }
+    return false;
+  }
+
   // loads an SSL context for hostname from the .crt file at path;
   SSLcontext loadContext(string path, string hostname, string keyFile){
     SSLcontext ctx;

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -82,8 +82,8 @@ version(SSL){
         writeln("[HTTPS]  HTTPS driver finished");
       }
 
-      override long receive(Socket socket, long maxsize = 4096){ synchronized {
-        long received;
+      override ptrdiff_t receive(Socket socket, ptrdiff_t maxsize = 4096){ synchronized {
+        ptrdiff_t received;
         if(ssl is null) return -1;
         char[] tmpbuffer = new char[](maxsize);
         if((received = SSL_read(ssl, cast(void*) tmpbuffer, cast(int)maxsize)) > 0) {

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -92,10 +92,10 @@ version(SSL){
         return(inbuffer.data.length);
       } }
 
-      override void send(ref Response response, Socket socket, long maxsize = 4096){ synchronized {
+      override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096){ synchronized {
         auto slice = response.bytes(maxsize);
         if(ssl is null) return;
-        long send = SSL_write(ssl, cast(void*) slice, cast(int) slice.length);
+        ptrdiff_t send = SSL_write(ssl, cast(void*) slice, cast(int) slice.length);
         if(send >= 0) {
           response.index += send; modtime = Clock.currTime(); senddata[requests] += send;
           if(response.index >= response.length) response.completed = true;

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -8,7 +8,7 @@ version(SSL){
   import std.string;
   import std.algorithm;
   import core.thread;
-  import core.stdc.stdlib : malloc, realloc;
+  import core.stdc.stdlib : malloc, realloc, free;
   import std.conv : to;
   import std.stdio : writefln, writeln;
   import core.stdc.stdio;
@@ -57,20 +57,25 @@ version(SSL){
 
   class HTTPS : DriverInterface {
     private:
-      SSL*                ssl;
+      SSL* ssl = null;
 
     public:
       this(Socket socket, bool blocking = false) {
-        this.ssl = SSL_new(contexts[0].context);            // writefln("[INFO]   SSL created, using standard certificate contexts[0].context");
-        writefln("[HTTPS]  initial SSL tunnel created");
-        SSL_set_fd(this.ssl, socket.handle());              // writefln("[INFO]   Added socket handle");
-        sslAssert(SSL_accept(this.ssl) != -1);
-        this.socket           = socket;
-        this.socket.blocking  = blocking;
-        this.starttime        = Clock.currTime();           /// Time in ms since this process came alive
-        this.modtime          = Clock.currTime();           /// Time in ms since this process was modified
+        this.socket = socket;
+        if(ncontext > 0) {
+          this.ssl = SSL_new(contexts[0].context);            // writefln("[INFO]   SSL created, using standard certificate contexts[0].context");
+          writefln("[HTTPS]  initial SSL tunnel created");
+          SSL_set_fd(this.ssl, socket.handle());              // writefln("[INFO]   Added socket handle");
+          sslAssert(SSL_accept(this.ssl) != -1);
+          this.socket.blocking = blocking;
+        } else {
+          writeln("[HTTPS]  HTTPS driver failed, reason: no certificate");
+          socket.close();
+        }
+        this.starttime = Clock.currTime();           /// Time in ms since this process came alive
+        this.modtime = Clock.currTime();           /// Time in ms since this process was modified
         try {
-          this.address        = socket.remoteAddress();
+          this.address = socket.remoteAddress();
         } catch(Exception e) {
           writefln("[WARN]   unable to resolve requesting origin");
         }
@@ -79,8 +84,9 @@ version(SSL){
 
       override long receive(Socket socket, long maxsize = 4096){ synchronized {
         long received;
+        if(ssl is null) return -1;
         char[] tmpbuffer = new char[](maxsize);
-        if((received = SSL_read(ssl, cast(void*) tmpbuffer, cast(int)maxsize)) > 0){
+        if((received = SSL_read(ssl, cast(void*) tmpbuffer, cast(int)maxsize)) > 0) {
           inbuffer.put(tmpbuffer[0 .. received]); modtime = Clock.currTime();
         }
         return(inbuffer.data.length);
@@ -88,14 +94,15 @@ version(SSL){
 
       override void send(ref Response response, Socket socket, long maxsize = 4096){ synchronized {
         auto slice = response.bytes(maxsize);
+        if(ssl is null) return;
         long send = SSL_write(ssl, cast(void*) slice, cast(int) slice.length);
-        if(send >= 0){
+        if(send >= 0) {
           response.index += send; modtime = Clock.currTime(); senddata[requests] += send;
           if(response.index >= response.length) response.completed = true;
         }
       } }
 
-      override bool isSecure(){ return(true); }
+      override bool isSecure() { return(true); }
   }
 
   SSL_CTX* getCTX(string CertFile, string KeyFile) {
@@ -113,17 +120,27 @@ version(SSL){
     OpenSSL_add_all_algorithms();
     SSL_load_error_strings();
     contexts = cast(SSLcontext*) malloc(0 * SSLcontext.sizeof);
-    foreach (DirEntry d; dirEntries(CertDir, SpanMode.shallow)){
+    writefln("[HTTPS]  Certificate folder: %d", exists(CertDir));
+    if (!exists(CertDir)) {
+      writefln("[WARN]   SSL certificate folder '%s' not found", CertDir);
+      return contexts;
+    }
+    if (!isDir(CertDir)) {
+      writefln("[WARN]   SSL certificate folder '%s' not a folder", CertDir);
+      return contexts;
+    }
+    foreach (DirEntry d; dirEntries(CertDir, SpanMode.shallow)) {
       if(d.name.endsWith(".crt")){
-        writefln("[INFO]   Loading certificate: %s", d.name);
+        writefln("[INFO]   loading certificate from file: %s", d.name);
         SSLcontext ctx;
         ctx.hostname = d.name[CertDir.length .. ($-4)] ~ "\0";
         ctx.context = getCTX(d.name, KeyFile);
-        writeln(ctx);
+        writefln("[INFO]   context created for certificate: %s", to!string(ctx.hostname.ptr));
+
         SSL_CTX_set_tlsext_servername_callback(ctx.context, cast(ExternC!(void function())) &switchContext);
-        //SSL_CTX_set_tlsext_servername_arg(ctx.context, &server);
         contexts = cast(SSLcontext*) realloc(contexts, (ncontext+1) * SSLcontext.sizeof);
         contexts[ncontext] = ctx;
+        writefln("[HTTPS]  stored certificate: %s in context: %d", to!string(ctx.hostname.ptr), ncontext);
         ncontext++;
       }
     }
@@ -132,12 +149,14 @@ version(SSL){
   }
 
   void closeSSL(Socket socket) {
-    writefln("[HTTPS]  closing socket");
+    writefln("[INFO]   closing server SSL socket");
     socket.close();
+    writefln("[INFO]   cleaning up %d HTTPS contexts", ncontext);
     for(int x = 0; x < ncontext; x++) {
       // Free the different SSL contexts
       SSL_CTX_free(contexts[x].context);
     }
+    free(contexts);
   }
 
   void sslAssert(bool ret){ if (!ret) {

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -75,8 +75,8 @@ version(SSL){
           writeln("[HTTPS]  HTTPS driver failed, reason: no certificate");
           socket.close();
         }
-        this.starttime = Clock.currTime();           /// Time in ms since this process came alive
-        this.modtime = Clock.currTime();           /// Time in ms since this process was modified
+        this.starttime = Clock.currTime();            /// Time in ms since this process came alive
+        this.modtime = Clock.currTime();              /// Time in ms since this process was modified
         try {
           this.address = socket.remoteAddress();
         } catch(Exception e) {
@@ -133,7 +133,7 @@ version(SSL){
 
   // loads all crt files in the certDir, using keyfile: server.key
   SSLcontext* initSSL(Server server, string certDir = ".ssl/", string keyFile = ".ssl/server.key", VERSION v = SSL23) {
-    writefln("[HTTPS]  loading Deimos.openSSL, from %s using key: %s, SSL:%s", certDir, certDir, v);
+    writefln("[HTTPS]  loading Deimos.openSSL, certificate: %s, priv.key: %s, SSL:%s", certDir, keyFile, v);
     SSL_library_init();
     OpenSSL_add_all_algorithms();
     SSL_load_error_strings();
@@ -145,6 +145,14 @@ version(SSL){
     }
     if (!isDir(certDir)) {
       writefln("[WARN]   SSL certificate folder '%s' not a folder", certDir);
+      return contexts;
+    }
+    if (!exists(keyFile)) {
+      writefln("[WARN]   SSL private key file: '%s' not found", certDir);
+      return contexts;
+    }
+    if (!isFile(keyFile)) {
+      writefln("[WARN]   SSL private key file: '%s' not a file", certDir);
       return contexts;
     }
     string hostname;

--- a/dub.json
+++ b/dub.json
@@ -6,7 +6,8 @@
 	"importPaths": ["danode"],
 	"sourcePaths": ["danode"],
 	"mainSourceFile": "danode/server.d",
-	"targetPath": "server",
+	"targetPath": "danode",
+	"targetName": "server",
 	"configurations": [
   {
 		"name": "default",

--- a/sh/letsEncrypt
+++ b/sh/letsEncrypt
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Setup some dependancies for the certbot-auto executable
+sudo apt-get install python-pip python-dev build-essential libffi-dev
+sudo pip install virtualenv
+
+# Download the certbot from eff.org
+wget https://dl.eff.org/certbot-auto
+
+# Make the script executable
+chmod a+x certbot-auto
+
+# Create a folder holding all the .ssl related files
+mkdir .ssl
+
+# Generate a Server Private key (ONLY ONCE, Backup your key !!)
+# [uncomment] openssl genrsa 4096 > .ssl/server.key
+# Create a backup of your key !
+# [uncomment] cp .ssl/server.key <backup>/server.key.backup
+
+# Secure via SSL the domain: mydomain.com using Let's Encrypt
+# - Generate certificate signing request for domain (? only once ?)
+# - Run the script in stand-alone mode, and request certificate for mydomain.com
+# - Copy the received certificate to the correct location and use the name: mydomain.com.crt
+# - Create folder, and move all the received files (cert, chain and parent) to a safe location
+
+openssl req -new -sha256 -key .ssl/server.key -subj "/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=DNS:mydomain.com,DNS:www.mydomain.com")) > .ssl/mydomain.nl.csr
+~/downloads/certbot-auto certonly --no-bootstrap --csr .ssl/mydomain.com.csr --standalone --email MyEmail@EMail.com --agree-tos
+cp 0000_cert.pem .ssl/mydomain.com.crt
+mkdir .ssl/mydomain.com/
+mv *.pem .ssl/mydomain.com/
+


### PR DESCRIPTION
- SSL/HTTPS support via [Let's Encrypt](https://letsencrypt.org/), see script [sh/letsEncrypt](sh/letsEncrypt)
- When a certificate is found it is enforced (all connections via HTTPS)
- Compiles and runs under windows 10, quality unknown, openssl not tested under windows
- Added more command line parameters: wwwRoot, certDir, keyFile
- Removes a couple of minor bugs
- Updates to the readme