### PR TITLE
Development -> Master

### DIFF
--- a/danode/cgi.d
+++ b/danode/cgi.d
@@ -81,7 +81,8 @@ class CGI : Payload {
     // Get the first line of the header
     @property final string firstHeaderLine() const {
       string outputSoFar = to!string(external.output(0));
-      return(outputSoFar[0 .. outputSoFar.indexOf("\n")]);
+      ptrdiff_t i = outputSoFar.indexOf("\n");
+      return(i > 0 ? outputSoFar[0 .. i] : outputSoFar);
     }
 
     // Return the status code provided by the external script

--- a/danode/client.d
+++ b/danode/client.d
@@ -68,7 +68,10 @@ class Client : Thread, ClientInterface {
           Thread.sleep(dur!"msecs"(2));
         }
       } catch(Exception e) { 
-        warning("unknown client exception: %s", e);
+        warning("Unknown Client Exception: %s", e);
+        stop();
+      } catch(Error e) {
+        warning("Unknown Client Error: %s", e);
         stop();
       }
       custom(1, "CLIENT", "connection %s:%s (%s) closed after %d requests %s (%s msecs)", ip, port, (driver.isSecure() ? "SSL" : "HTTP"), 

--- a/danode/post.d
+++ b/danode/post.d
@@ -86,11 +86,11 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
     string[] elem = strip(part).split("\r\n");
     if (elem[0] != "--") {
       string[] mphdr = elem[0].split("; ");
-      string key = mphdr[1][6 .. ($-1)];
+      string key = mphdr[1].length > 6 ? mphdr[1][6 .. ($-1)] : "";
       if (mphdr.length == 2) {
         request.postinfo[key] = PostItem(PostType.Input, key, "", join(elem[2 .. ($-1)]));
       } else if (mphdr.length == 3) {
-        string fname = mphdr[2][10 .. ($-1)];
+        string fname = mphdr[2].length > 10 ? mphdr[2][10 .. ($-1)] : "";
         custom(1, "MPART", "found on key %s file %s", key, fname);
         if (key.length > 2) {
           isarraykey = (key[($-2) .. $] == "[]")? true : false;
@@ -104,7 +104,7 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
           string mpcontent = join(elem[3 .. ($-1)], "\r\n");
           auto mimeParts = split(elem[1], ": ");
           string fileMime = mimeParts.length >= 2 ? mimeParts[1] : "application/octet-stream";
-          request.postinfo[fkey] = PostItem(PostType.File, skey, mphdr[2][10 .. ($-1)], localpath, fileMime, mpcontent.length);
+          request.postinfo[fkey] = PostItem(PostType.File, skey, fname, localpath, fileMime, mpcontent.length);
           writeinfile(localpath, mpcontent);
           custom(1, "MPART", "wrote %d bytes to file %s", mpcontent.length, localpath);
         } else {

--- a/danode/post.d
+++ b/danode/post.d
@@ -73,7 +73,7 @@ final bool parsePost (ref Request request, ref Response response, in FileSystem 
 final void parseXform(ref Request request, const string content) {
   foreach (s; content.split("&")) {
     string[] elem = strip(s).split("=");
-    request.postinfo[ elem[0] ] = PostItem( PostType.Input, elem[0], "", elem[1] );
+    request.postinfo[elem[0]] = PostItem(PostType.Input, elem[0], "", (elem.length > 1)? elem[1] : "" );
   }
 }
 

--- a/danode/post.d
+++ b/danode/post.d
@@ -52,7 +52,9 @@ final bool parsePost (ref Request request, ref Response response, in FileSystem 
     request.parseXform(content);
     custom(1, "XFORM", "# of items: %s", request.postinfo.length);
   } else if (contenttype.indexOf(MPHEADER) >= 0) {
-    string mpid = split(contenttype, "boundary=")[1];
+    auto parts = split(contenttype, "boundary=");
+    if (parts.length < 2) return response.havepost = true;
+    string mpid = parts[1];
     custom(1, "MPART", "header: %s, parsing %d bytes", mpid, expectedlength);
     request.parseMultipart(filesystem, content, mpid);
     custom(1, "MPART", "# of items: %s", request.postinfo.length);
@@ -100,7 +102,9 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
           string skey = isarraykey? key[0 .. $-2] : key;
           string localpath = request.uploadfile(filesystem, fkey);
           string mpcontent = join(elem[3 .. ($-1)], "\r\n");
-          request.postinfo[fkey] = PostItem(PostType.File, skey, mphdr[2][10 .. ($-1)], localpath, split(elem[1],": ")[1], mpcontent.length);
+          auto mimeParts = split(elem[1], ": ");
+          string fileMime = mimeParts.length >= 2 ? mimeParts[1] : "application/octet-stream";
+          request.postinfo[fkey] = PostItem(PostType.File, skey, mphdr[2][10 .. ($-1)], localpath, fileMime, mpcontent.length);
           writeinfile(localpath, mpcontent);
           custom(1, "MPART", "wrote %d bytes to file %s", mpcontent.length, localpath);
         } else {

--- a/danode/process.d
+++ b/danode/process.d
@@ -131,7 +131,10 @@ class Process : Thread {
           buffer.put(cast(char) ch);
         }
       } catch (Exception e) {
-        warning("exception during readpipe command: %s", e.msg);
+        warning("Exception during readpipe command: %s", e);
+        file.close();
+      } catch(Error e) {
+        warning("Error during readpipe command: %s", e);
         file.close();
       }
     }

--- a/danode/response.d
+++ b/danode/response.d
@@ -105,7 +105,8 @@ struct Response {
   @property final const(char)[] bytes(in ptrdiff_t maxsize = 1024) {                       // Stream of bytes (header + stream of bytes)
     ptrdiff_t hsize = header.length;
     if(index <= hsize) {  // We haven't completed the header yet
-      return(header[index .. hsize] ~ payload.bytes(0, maxsize-hsize));
+      ptrdiff_t remaining = maxsize - hsize;
+      return(header[index .. hsize] ~ payload.bytes(0, remaining > 0 ? remaining : 0));
     }
     return(payload.bytes(index-hsize));                                                    // Header completed, just stream bytes from the payload
   }

--- a/danode/server.d
+++ b/danode/server.d
@@ -115,7 +115,8 @@ class Server : Thread {
       Appender!(Client[]) persistent;
       while(running) {
         try {
-          persistent.clear();
+          Client[] previous = clients;                            // Slice reference
+          persistent.clear();                                     // Clear the Appender
           if ((select = set.sISelect(socket)) > 0) {
             custom(3, "SERVER", "accepting HTTP request");
             Client client = this.accept(socket);
@@ -128,7 +129,10 @@ class Server : Thread {
               if(client !is null) persistent.put(client);
             }
           }
-          foreach(Client client; clients){ if(client.running){ persistent.put(client); } }        // Add the backlog of persistent clients
+          foreach (Client client; previous) {   // Foreach through the Slice reference
+            if(client.running) persistent.put(client);          // Add the backlog of persistent clients
+            else if(!client.isRunning) client.join();           // join finished threads
+          }
           clients = persistent.data;
         } catch(Exception e) {
           error("Unspecified top level server error: %s", e.msg);


### PR DESCRIPTION
DaNode development branch — fixes applied:

OpenSSL 1.0 vs 1.1 — version(OpenSSL_1_0) block in ssl.d, set via dub.json
Double HTTP header bug — root cause was php-cgi wrapping PHP headers; fixed by switching to php in mimetypes.d
SERVER_PROTOCOL=v11 → cast(string)request.protocol in post.d
Silent crashes → catch(Error e) added in client.d and process.d
clients use-after-free → Client[] previous = clients before persistent.clear()
Array OOB in cgi.d → indexOf("\n") guard in firstHeaderLine()
Array OOB in post.d → boundary= split guard, mphdr[1/2] length guards, elem[1] guard, fname reuse
Array OOB in response.d → remaining > 0 guard in bytes()
StatusCode lookup → EnumMembers iteration in cgi.d

Still to consider:

Fuzz testing HTTP/POST parser with malformed inputs
Upgrade Debian 8 (biggest actual security risk)
Thread joining for dead clients