### PR TITLE
Security audit fixes, robustness improvements, and code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ www/mapctl.org/
 
 *.in
 *.err
+*.png
+*.jpg
 *.lst
 *.log
 *.def

--- a/danode/cgi.d
+++ b/danode/cgi.d
@@ -16,8 +16,8 @@ class CGI : Payload {
     string command;
     string path;
 
-    this(string command, string path, bool removeInput = true, long maxtime = 4500){
-      this.command = command;
+    this(string[] command, string path, bool removeInput = true, long maxtime = 4500){
+      this.command = command.join(" ");
       this.path = path;
       external = new Process(command, path, removeInput, maxtime); 
       external.start();

--- a/danode/cgi.d
+++ b/danode/cgi.d
@@ -29,7 +29,7 @@ class CGI : Payload {
     // Is the payload ready ?
     final @property long ready() { return(external.finished); }
 
-    // length of the message portion of the output (generated HTML headers are detected and substracted)
+    // length of the message portion of the output (generated HTTP headers are detected and substracted)
     final @property ptrdiff_t length() const {
       if (!external.running) {
         ptrdiff_t msglength = to!ptrdiff_t(external.length);

--- a/danode/client.d
+++ b/danode/client.d
@@ -9,7 +9,7 @@ import danode.request : Request;
 import danode.payload : Message;
 import danode.log : custom, info, trace, warning, NOTSET, NORMAL;
 
-immutable size_t MAX_REQUEST_SIZE = 1024 * 1024 * 10; // 10MB upload limit
+immutable size_t MAX_REQUEST_SIZE = 1024 * 1024 * 100; // 100MB upload limit
 
 class Client : Thread, ClientInterface {
   private:

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -31,7 +31,7 @@ class FileSystem {
   public:
     this(Log logger, string root = "./www/", size_t maxsize = 1024 * 512){
       this.logger   = logger;
-      this.root     = root.endsWith("/") ? root : root ~ "/";     // Normalized root (always ends with /)
+      this.root = buildNormalizedPath(absolutePath(root)) ~ "/";
       this.maxsize  = maxsize;
       scan();
     }

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -76,7 +76,10 @@ class FileSystem {
 
     /* Get the FilePayload at path from the localroot, with update check on buffers */
     final FilePayload file(string localroot, string path){ synchronized {
-      // New file created after last scan ? -> Scan the whole folder for changes
+      if (!(localroot in domains)) {
+        warning("file(): unknown domain '%s'", localroot);
+        return new FilePayload("", maxsize);
+      }
       if (!domains[localroot].files.has(path) && exists(format("%s%s", localroot, path))) {
         custom(1, "SCAN", "New file %s, rescanning index: %s", path, localroot);
         domains[localroot] = scan(localroot);

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -29,7 +29,6 @@ SysTime parseHtmlDate(const string datestr) {
   return(ts);
 }
 
-pure string shellEscape(string s) { return "'" ~ s.replace("'", "'\\''") ~ "'"; }
 pure string htmlEscape(string s) {
   return(s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&#39;"));
 }

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -63,6 +63,20 @@ pure string toD(T, U)(in T x, in U digits = 6) nothrow {
   return((key in buffer) !is null);
 }
 
+string[string] parseQueryString(const string query, const string defVal = "") {
+  string[string] params;
+  foreach (param; query.split("&")) {
+    try {
+      string s     = strip(param);
+      ptrdiff_t i  = s.indexOf("=");
+      string key   = decodeComponent(i > 0 ? s[0 .. i]   : s);
+      string value = decodeComponent(i > 0 ? s[i+1 .. $] : defVal);
+      if (key.length > 0) params[key] = value;
+    } catch (Exception e) { warning("parseQueryString: failed to decode '%s'", param); }
+  }
+  return params;
+}
+
 @nogc pure bool has(T)(in T[] buffer, in T key) nothrow {
   foreach(T i; buffer) { 
     if(i == key) return(true);

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -38,11 +38,12 @@ pure string htmlEscape(string s) {
 string safePath(in string root, in string path) {
   if (path.canFind("..")) return null;
   if (path.canFind("\0")) return null;
-  string full = root ~ (path.startsWith("/") ? path[1..$] : path);
+  string full = root ~ (path.startsWith("/") ? path : "/" ~ path);
   try {
     if (exists(full)) {
+      string absroot  = buildNormalizedPath(absolutePath(root));
       string resolved = buildNormalizedPath(absolutePath(full));
-      if (!resolved.startsWith(root)) return null;
+      if (resolved != absroot && !resolved.startsWith(absroot ~ "/")) return null;
     }
   } catch (Exception e) { return null; }
   return full;
@@ -100,10 +101,10 @@ string[string] parseQueryString(const string query, const string defVal = "") {
 void writeinfile(in string localpath, in string content) {
   if (content.length > 0) { 
     try {
-    auto fp = File(localpath, "wb");
-         fp.rawWrite(content);
-         fp.close();
-         trace("writeinfile: %d bytes to: %s", content.length, localpath);
+      auto fp = File(localpath, "wb");
+      fp.rawWrite(content);
+      fp.close();
+      trace("writeinfile: %d bytes to: %s", content.length, localpath);
     } catch(Exception e) {
       error("writeinfile: I/O exception '%s'", e.msg);
     }

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -38,7 +38,14 @@ pure string htmlEscape(string s) {
 string safePath(in string root, in string path) {
   if (path.canFind("..")) return null;
   if (path.canFind("\0")) return null;
-  return(root ~ (path.startsWith("/") ? path : "/" ~ path));
+  string full = root ~ (path.startsWith("/") ? path[1..$] : path);
+  try {
+    if (exists(full)) {
+      string resolved = buildNormalizedPath(absolutePath(full));
+      if (!resolved.startsWith(root)) return null;
+    }
+  } catch (Exception e) { return null; }
+  return full;
 }
 
 // Month to index of the year

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -160,7 +160,7 @@ pure ptrdiff_t bodystart(T)(const(T) buffer) {
   return(-1);
 }
 
-// get the HTML header contained in the buffer
+// get the HTTP header contained in the buffer
 pure string fullheader(T)(const(T) buffer) {
   auto i = bodystart(buffer);
   if (i > 0 && i <= buffer.length)

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -43,7 +43,7 @@ string safePath(in string root, in string path) {
 
 // Month to index of the year
 pure int monthToIndex(in string m) {
-  for (int x = 1; x < 12; ++x) {
+  for (int x = 1; x <= 12; ++x) {
     if(m.toLower() == months[x].toLower()) return x;
   }
   return -1;
@@ -112,27 +112,21 @@ string htmltime(in SysTime d = Clock.currTime()) {
 bool isFILE(in string path) {
   try {
     if (exists(path) && isFile(path)) return true;
-  } catch(Exception e) {
-    error("isFILE: I/O exception '%s'", e.msg);
-  }
+  } catch(Exception e) { error("isFILE: I/O exception '%s'", e.msg); }
   return false;
 }
 
 bool isDIR(in string path) {
   try {
     if (exists(path) && isDir(path)) return true;
-  } catch(Exception e) {
-    error("isDIR: I/O exception '%s'", e.msg);
-  }
+  } catch(Exception e) { error("isDIR: I/O exception '%s'", e.msg); }
   return false;
 }
 
 bool isCGI(in string path) {
   try {
     if (exists(path) && isFile(path) && mime(path).indexOf(CGI_FILE) >= 0) return true;
-  } catch(Exception e) {
-    error("isCGI: I/O exception '%s'", e.msg);
-  }
+  } catch(Exception e) { error("isCGI: I/O exception '%s'", e.msg); }
   return false;
 }
 
@@ -141,7 +135,7 @@ pure bool isAllowed(in string path) {
   return true;
 }
 
-// Where does the HTML request header end ?
+// Where does the HTTP request header end ?
 pure ptrdiff_t endofheader(T)(const(T) buffer) {
   auto str = to!string(buffer);
   ptrdiff_t idx = str.indexOf("\r\n\r\n");
@@ -149,7 +143,7 @@ pure ptrdiff_t endofheader(T)(const(T) buffer) {
   return(idx);
 }
 
-// Where does the HTML request body start ?
+// Where does the HTTP request body start ?
 pure ptrdiff_t bodystart(T)(const(T) buffer) {
   auto str = to!string(buffer);
   ptrdiff_t idx = str.indexOf("\r\n\r\n");

--- a/danode/https.d
+++ b/danode/https.d
@@ -49,8 +49,8 @@ version(SSL) {
       // Open the connection by setting the socket to non blocking I/O, and registering the origin address
       override bool openConnection() { synchronized {
         custom(1, "HTTPS", "Opening HTTPS connection");
-        if (ncontext > 0) {
-          custom(1, "HTTPS", "Number of SSL contexts: %d", ncontext);
+        if (contexts.length > 0) {
+          custom(1, "HTTPS", "Number of SSL contexts: %d", contexts.length);
           try {
             if (this.socket is null) {
               error("SSL was not given a valid socket (null)");

--- a/danode/imports.d
+++ b/danode/imports.d
@@ -13,7 +13,7 @@ public import std.conv : to;
 public import std.datetime : dur, msecs;
 public import std.getopt : getopt;
 public import std.path : baseName, extension, absolutePath, buildNormalizedPath;
-public import std.process : pipe, spawnShell, executeShell, tryWait, wait, kill;
+public import std.process : pipe, spawnProcess, tryWait, wait, kill;
 public import std.file : dirEntries, exists, remove, isFile, isDir, timeLastModified, getSize;
 public import std.format : format, formatValue;
 public import std.regex : regex, match;

--- a/danode/interfaces.d
+++ b/danode/interfaces.d
@@ -69,10 +69,10 @@ abstract class DriverInterface {
       return(to!string(inbuffer.data[bodyStart() .. $]));
     }
 
-    // Where does the HTML request header end ?
+    // Where does the HTTP request header end ?
     final @property ptrdiff_t endOfHeader() const { return(endofheader(inbuffer.data)); }
 
-    // Where does the HTML request body begin ?
+    // Where does the HTTP request body begin ?
     final @property ptrdiff_t bodyStart() const { return(bodystart(inbuffer.data)); }
 
     // Do we have a header separator ? "\r\n\r\n" or "\n\n"

--- a/danode/post.d
+++ b/danode/post.d
@@ -81,42 +81,55 @@ final void parseXform(ref Request request, const string content) {
   foreach (k, v; parseQueryString(content)) { request.postinfo[k] = PostItem(PostType.Input, k, "", v); }
 }
 
+// Extract value from: name="value" or filename="value"
+pure string extractQuoted(string s, string key) nothrow {
+  ptrdiff_t i = s.indexOf(key ~ "=\"");
+  if (i < 0) return "";
+  i += key.length + 2;
+  ptrdiff_t j = s.indexOf("\"", i);
+  return j > i ? s[i .. j] : "";
+}
+
+pure ptrdiff_t findBodyLine(in string[] lines) nothrow {
+  foreach (i, line; lines) { if (strip(line).length == 0) return i + 1; }
+  return -1;
+}
+
 // Parse Multipart content in the body of the request
 final void parseMultipart(ref Request request, in FileSystem filesystem, const string content, const string mpid) {
-  //writeinfile("multipart.txt", content);
   int[string] keys;
-  bool isarraykey;
-  foreach (size_t i, part; chomp(content).split(mpid)) {
+  foreach (part; chomp(content).split(mpid)) {
     string[] elem = strip(part).split("\r\n");
-    if (elem[0] != "--") {
-      string[] mphdr = elem[0].split("; ");
-      string key = mphdr[1].length > 6 ? mphdr[1][6 .. ($-1)] : "";
-      if (mphdr.length == 2) {
-        request.postinfo[key] = PostItem(PostType.Input, key, "", join(elem[2 .. ($-1)]));
-      } else if (mphdr.length == 3) {
-        string fname = mphdr[2].length > 10 ? mphdr[2][10 .. ($-1)] : "";
-        custom(1, "MPART", "found on key %s file %s", key, fname);
-        if (key.length > 2) {
-          isarraykey = (key[($-2) .. $] == "[]")? true : false;
-        }
-        keys[key] = keys.has(key)? keys[key] + 1: 0;
-        custom(1, "MPART", "found on key %s #%d file %s", key, keys[key], fname);
-        if (fname != "") {
-          string fkey = isarraykey? key ~ to!string(keys[key]) : key;
-          string skey = isarraykey? key[0 .. $-2] : key;
-          string localpath = request.uploadfile(filesystem, fkey);
-          string mpcontent = join(elem[3 .. ($-1)], "\r\n");
-          auto mimeParts = split(elem[1], ": ");
-          string fileMime = mimeParts.length >= 2 ? mimeParts[1] : "application/octet-stream";
-          request.postinfo[fkey] = PostItem(PostType.File, skey, fname, localpath, fileMime, mpcontent.length);
-          writeinfile(localpath, mpcontent);
-          custom(1, "MPART", "wrote %d bytes to file %s", mpcontent.length, localpath);
-        } else {
-          request.postinfo[key] = PostItem(PostType.Input, key, "");
-        }
-      }
-    }else{
-      custom(1, "MPART", "ID element: %s", elem[0]);
+    if (elem.length < 2 || elem[0] == "--") { custom(1, "MPART", "ID element: %s", elem.length > 0 ? elem[0] : ""); continue; }
+
+    string[] mphdr = elem[0].split("; ");
+    if (mphdr.length < 2) continue;
+
+    string key = extractQuoted(elem[0], "name");
+    if (key.length == 0) continue;
+
+    ptrdiff_t body = findBodyLine(elem);
+    if (body < 0 || body >= elem.length) continue;
+
+    if (mphdr.length == 2) {
+      request.postinfo[key] = PostItem(PostType.Input, key, "", join(elem[body .. ($-1)]));
+    } else if (mphdr.length >= 3) {
+      string fname = extractQuoted(elem[0], "filename");
+      custom(1, "MPART", "found on key %s file %s", key, fname);
+      bool isarraykey = key.length > 2 && key[($-2) .. $] == "[]";
+      keys[key] = keys.has(key) ? keys[key] + 1 : 0;
+      custom(1, "MPART", "found on key %s #%d file %s", key, keys[key], fname);
+      if (fname != "") {
+        string fkey      = isarraykey ? key ~ to!string(keys[key]) : key;
+        string skey      = isarraykey ? key[0 .. $-2] : key;
+        string localpath = request.uploadfile(filesystem, fkey);
+        string mpcontent = join(elem[body .. ($-1)], "\r\n");
+        auto mimeParts   = split(elem[body-1], ": ");
+        string fileMime  = mimeParts.length >= 2 ? mimeParts[1] : "application/octet-stream";
+        request.postinfo[fkey] = PostItem(PostType.File, skey, fname, localpath, fileMime, mpcontent.length);
+        writeinfile(localpath, mpcontent);
+        custom(1, "MPART", "wrote %d bytes to file %s", mpcontent.length, localpath);
+      } else { request.postinfo[key] = PostItem(PostType.Input, key, ""); }
     }
   }
 }

--- a/danode/post.d
+++ b/danode/post.d
@@ -108,11 +108,11 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
     string key = extractQuoted(elem[0], "name");
     if (key.length == 0) continue;
 
-    ptrdiff_t body = findBodyLine(elem);
-    if (body < 0 || body >= elem.length) continue;
+    ptrdiff_t bodyLine = findBodyLine(elem);
+    if (bodyLine < 0 || bodyLine >= elem.length) continue;
 
     if (mphdr.length == 2) {
-      request.postinfo[key] = PostItem(PostType.Input, key, "", join(elem[body .. ($-1)]));
+      request.postinfo[key] = PostItem(PostType.Input, key, "", join(elem[bodyLine .. ($-1)]));
     } else if (mphdr.length >= 3) {
       string fname = extractQuoted(elem[0], "filename");
       custom(1, "MPART", "found on key %s file %s", key, fname);
@@ -123,8 +123,8 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
         string fkey      = isarraykey ? key ~ to!string(keys[key]) : key;
         string skey      = isarraykey ? key[0 .. $-2] : key;
         string localpath = request.uploadfile(filesystem, fkey);
-        string mpcontent = join(elem[body .. ($-1)], "\r\n");
-        auto mimeParts   = split(elem[body-1], ": ");
+        string mpcontent = join(elem[bodyLine .. ($-1)], "\r\n");
+        auto mimeParts   = split(elem[bodyLine-1], ": ");
         string fileMime  = mimeParts.length >= 2 ? mimeParts[1] : "application/octet-stream";
         request.postinfo[fkey] = PostItem(PostType.File, skey, fname, localpath, fileMime, mpcontent.length);
         writeinfile(localpath, mpcontent);

--- a/danode/post.d
+++ b/danode/post.d
@@ -10,7 +10,7 @@ import danode.webconfig : WebConfig;
 import danode.payload : Message;
 import danode.mimetypes : mime;
 import danode.filesystem : FileSystem;
-import danode.functions : from, has, isCGI, isFILE, isDIR, writeinfile;
+import danode.functions : from, has, isCGI, isFILE, isDIR, writeinfile, parseQueryString;
 import danode.log : info, custom, trace, warning;
 
 immutable string      MPHEADER         = "multipart/form-data";                     /// Multipart header id
@@ -78,10 +78,7 @@ final bool parsePost (ref Request request, ref Response response, in FileSystem 
 
 // Parse X-form content in the body of the request
 final void parseXform(ref Request request, const string content) {
-  foreach (s; content.split("&")) {
-    string[] elem = strip(s).split("=");
-    request.postinfo[elem[0]] = PostItem(PostType.Input, elem[0], "", (elem.length > 1)? elem[1] : "" );
-  }
+  foreach (k, v; parseQueryString(content)) { request.postinfo[k] = PostItem(PostType.Input, k, "", v); }
 }
 
 // Parse Multipart content in the body of the request

--- a/danode/post.d
+++ b/danode/post.d
@@ -2,6 +2,7 @@ module danode.post;
 
 import danode.imports;
 import danode.cgi : CGI;
+import danode.client : MAX_REQUEST_SIZE;
 import danode.statuscode : StatusCode;
 import danode.request : Request;
 import danode.response : SERVERINFO, Response, redirect, create, notmodified;
@@ -11,8 +12,6 @@ import danode.mimetypes : mime;
 import danode.filesystem : FileSystem;
 import danode.functions : from, has, isCGI, isFILE, isDIR, writeinfile;
 import danode.log : info, custom, trace, warning;
-
-immutable long MAX_UPLOAD_SIZE = 1024 * 1024 * 100; // 100MB
 
 immutable string      MPHEADER         = "multipart/form-data";                     /// Multipart header id
 immutable string      XFORMHEADER      = "application/x-www-form-urlencoded";       /// X-form header id
@@ -42,7 +41,7 @@ final bool parsePost (ref Request request, ref Response response, in FileSystem 
     custom(2, "POST", "Content-Length was not specified or 0: real length: %s", content.length);
     response.havepost = true;
     return(true); // When we don't receive any post data it is meaningless to scan for any content
-  } else if (expectedlength > MAX_UPLOAD_SIZE) {
+  } else if (expectedlength > MAX_REQUEST_SIZE) {
     warning("Upload too large: %d bytes from %s", expectedlength, request.ip);
     response.payload = new Message(StatusCode.PayloadTooLarge, "413 - Payload Too Large\n");
     response.ready = true;

--- a/danode/process.d
+++ b/danode/process.d
@@ -195,6 +195,7 @@ class Process : Thread {
         this.completed = true;
       } catch(Exception e) {
         warning("process.d, exception: '%s'", e.msg);
+        this.completed = true;  // ADD THIS
       }
     }
 }

--- a/danode/process.d
+++ b/danode/process.d
@@ -39,7 +39,7 @@ version(Posix) {
    the error buffer will be served. only if the error buffer is empty, will outbuffer be served. */
 class Process : Thread {
   private:
-    string            command;              /// Command to execute
+    string[]          command;              /// Command to execute
     string            inputfile;            /// Path of input file
     bool              completed = false;
     bool              removeInput = true;
@@ -60,7 +60,7 @@ class Process : Thread {
     Appender!(char[])  errbuffer;           /// Error appender buffer
 
   public:
-    this(string command, string inputfile, bool removeInput = true, long maxtime = 4500) {
+    this(string[] command, string inputfile, bool removeInput = true, long maxtime = 4500) {
       this.command = command;
       this.inputfile = inputfile;
       this.removeInput = removeInput;
@@ -161,7 +161,7 @@ class Process : Thread {
         fStdIn = File(inputfile, "r");
         pStdOut = pipe(); pStdErr = pipe();
         custom(1, "PROC", "command: %s < %s", command, inputfile);
-        auto cpid = spawnShell(command, fStdIn, pStdOut.writeEnd, pStdErr.writeEnd, null);
+        auto cpid = spawnProcess(command, fStdIn, pStdOut.writeEnd, pStdErr.writeEnd, null);
 
         fStdOut = pStdOut.readEnd;
         if(!nonblocking(fStdOut) && fStdOut.isOpen()) custom(2, "WARN", "unable to create nonblocking stdout pipe for command");

--- a/danode/request.d
+++ b/danode/request.d
@@ -161,9 +161,9 @@ struct Request {
   final @property string useragent() const { return(headers.from("User-Agent", "Unknown")); }
   final string shorthost() const { return( (host.indexOf("www.") >= 0)? host[4 .. $] : host ); }
   final string[] command(string localpath) const {
-    string interp = localpath.interpreter();
-    string[] args = interp.length > 0 ? [interp, localpath] : [localpath];
-    foreach(k; get.byKey()) { args ~= shellEscape(k ~ "=" ~ get[k]); }
+    string interp  = localpath.interpreter();
+    string[] args  = interp.length > 0 ? interp.split(" ") ~ localpath : [localpath];
+    foreach(k; get.byKey()) { args ~= k ~ "=" ~ get[k]; }
     return args;
   }
   final @property string    params() const {

--- a/danode/request.d
+++ b/danode/request.d
@@ -161,14 +161,15 @@ struct Request {
   final @property string useragent() const { return(headers.from("User-Agent", "Unknown")); }
   final string shorthost() const { return( (host.indexOf("www.") >= 0)? host[4 .. $] : host ); }
   final string[] command(string localpath) const {
-    string[] args = [localpath.interpreter(), localpath];
+    string interp = localpath.interpreter();
+    string[] args = interp.length > 0 ? [interp, localpath] : [localpath];
     foreach(k; get.byKey()) { args ~= shellEscape(k ~ "=" ~ get[k]); }
-    return(args);
+    return args;
   }
   final @property string    params() const {
-      Appender!string str; 
-      foreach(k; get.byKey()){ str.put(format(" %s", shellEscape(k ~ "=" ~ get[k]))); }
-      return(str.data); 
+    Appender!string str; 
+    foreach(k; get.byKey()){ str.put(format(" %s", shellEscape(k ~ "=" ~ get[k]))); }
+    return(str.data); 
   }
 
   // Canonical redirect of the Request for a directory to the index page specified in the WebConfig

--- a/danode/request.d
+++ b/danode/request.d
@@ -3,7 +3,7 @@ module danode.request;
 import danode.imports;
 import danode.filesystem : FileSystem;
 import danode.interfaces : ClientInterface, DriverInterface;
-import danode.functions : interpreter, from, parseHtmlDate, parseQueryString, shellEscape;
+import danode.functions : interpreter, from, parseHtmlDate, parseQueryString;
 import danode.webconfig : WebConfig;
 import danode.http : HTTP;
 import danode.post : PostItem, PostType;
@@ -165,11 +165,6 @@ struct Request {
     string[] args  = interp.length > 0 ? interp.split(" ") ~ localpath : [localpath];
     foreach(k; get.byKey()) { args ~= k ~ "=" ~ get[k]; }
     return args;
-  }
-  final @property string    params() const {
-    Appender!string str; 
-    foreach(k; get.byKey()){ str.put(format(" %s", shellEscape(k ~ "=" ~ get[k]))); }
-    return(str.data); 
   }
 
   // Canonical redirect of the Request for a directory to the index page specified in the WebConfig

--- a/danode/request.d
+++ b/danode/request.d
@@ -43,7 +43,7 @@ pure bool parseRequestLine(ref Request request, const string line) {
 struct Request {
   string ip; /// IP location of the client
   long port; /// Port at which the client is connected
-  string body; /// the body of the HTMLrequest
+  string body; /// the body of the HTTP request
   bool isSecure; /// was a secure request made
   bool isValid; /// Is the header valid ?
   UUID id; /// md5UUID for this request
@@ -72,7 +72,7 @@ struct Request {
     trace("request header: %s", driver.header);
   }
 
-  // Parse the HTML request header (method, uri, protocol) as well as the supplemental headers
+  // Parse the HTTP request header (method, uri, protocol) as well as the supplemental headers
   final bool parseHeader(const string header) {
     try {
       foreach (i, line; header.replace("\r\n", "\n").split("\n")) {
@@ -115,7 +115,7 @@ struct Request {
     return(headers.from("Host")); 
   }
 
-  // The Post from the Host header in the request
+  // The Port from the Host header in the request
   final @property ushort serverport() const {
     ptrdiff_t i = headers.from("Host").indexOf(":");
     if (i > 0) { 

--- a/danode/request.d
+++ b/danode/request.d
@@ -31,10 +31,9 @@ pure HTTPVersion parseHTTPVersion(const string line) {
 // Parse the Request-Line: "method uri protocol"
 pure bool parseRequestLine(ref Request request, const string line) {
   auto parts = line.split(" ");
-  if (parts.length < 3)
-    throw new Exception(format("malformed Request-Line: '%s'", line));
-
+  if (parts.length < 3) { throw new Exception(format("malformed Request-Line: '%s'", line)); }
   request.method = to!RequestMethod(strip(parts[0]));
+  // uri and url start identical; url may be rewritten during routing, uri is preserved as-is
   request.uri = request.url = strip(join(parts[1 .. ($-1)], " "));
   request.protocol = parseHTTPVersion(strip(parts[($-1)]));
   return(true);
@@ -48,8 +47,8 @@ struct Request {
   bool isValid; /// Is the header valid ?
   UUID id; /// md5UUID for this request
   RequestMethod method; /// requested HTTP method
-  string uri = "/"; /// uri requested
-  string url = "/"; /// url requested
+  string uri = "/"; /// raw URI from the request line, never modified after parsing
+  string url = "/"; /// working path used for routing, may be rewritten by canonical/directory redirects
   string page; /// page is used when performing a canonical redirect
   string dir; /// dir is used in directory redirection
   HTTPVersion protocol; /// protocol requested
@@ -146,8 +145,13 @@ struct Request {
     return(files);
   }
 
+  // decoded path component of url (post-rewrite)
   final @property string path() const { ptrdiff_t i = url.indexOf("?"); if(i > 0){ return(url[0 .. i]); }else{ return(url); } }
+
+  // query string component of uri (pre-rewrite)
   final @property string query() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[i .. $]); }else{ return("?"); } }
+
+  // path component of uri (pre-rewrite, used for canonical redirects)
   final @property string uripath() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[0 .. i]); }else{ return(uri); } }
   final @property bool keepalive() const { return( toLower(headers.from("Connection")) == "keep-alive"); }
   final @property SysTime ifModified() const { return(parseHtmlDate(headers.from("If-Modified-Since"))); }

--- a/danode/request.d
+++ b/danode/request.d
@@ -75,7 +75,7 @@ struct Request {
   // Parse the HTML request header (method, uri, protocol) as well as the supplemental headers
   final bool parseHeader(const string header) {
     try {
-      foreach (i, line; header.split("\n")) {
+      foreach (i, line; header.replace("\r\n", "\n").split("\n")) {
         if (i == 0) {
           this.parseRequestLine(line);
         } else { // next lines: header-param: attribute 

--- a/danode/request.d
+++ b/danode/request.d
@@ -150,17 +150,21 @@ struct Request {
     return(files);
   }
 
-  final @property string    path() const { ptrdiff_t i = url.indexOf("?"); if(i > 0){ return(url[0 .. i]); }else{ return(url); } }
-  final @property string    query() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[i .. $]); }else{ return("?"); } }
-  final @property string    uripath() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[0 .. i]); }else{ return(uri); } }
-  final @property bool      keepalive() const { return( toLower(headers.from("Connection")) == "keep-alive"); }
-  final @property SysTime   ifModified() const { return(parseHtmlDate(headers.from("If-Modified-Since"))); }
-  final @property bool      acceptsEncoding(string encoding = "deflate") const { return(headers.from("Accept-Encoding").canFind(encoding)); }
-  final @property bool      track() const { return(  headers.from("DNT","0") == "0"); }
-  final @property string    cookies() const { return(headers.from("Cookie")); }
-  final @property string    useragent() const { return(headers.from("User-Agent", "Unknown")); }
-  final string              shorthost() const { return( (host.indexOf("www.") >= 0)? host[4 .. $] : host ); }
-  final string              command(string localpath) const { return(format("%s %s%s", localpath.interpreter(), localpath, params())); }
+  final @property string path() const { ptrdiff_t i = url.indexOf("?"); if(i > 0){ return(url[0 .. i]); }else{ return(url); } }
+  final @property string query() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[i .. $]); }else{ return("?"); } }
+  final @property string uripath() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[0 .. i]); }else{ return(uri); } }
+  final @property bool keepalive() const { return( toLower(headers.from("Connection")) == "keep-alive"); }
+  final @property SysTime ifModified() const { return(parseHtmlDate(headers.from("If-Modified-Since"))); }
+  final @property bool acceptsEncoding(string encoding = "deflate") const { return(headers.from("Accept-Encoding").canFind(encoding)); }
+  final @property bool track() const { return(  headers.from("DNT","0") == "0"); }
+  final @property string cookies() const { return(headers.from("Cookie")); }
+  final @property string useragent() const { return(headers.from("User-Agent", "Unknown")); }
+  final string shorthost() const { return( (host.indexOf("www.") >= 0)? host[4 .. $] : host ); }
+  final string[] command(string localpath) const {
+    string[] args = [localpath.interpreter(), localpath];
+    foreach(k; get.byKey()) { args ~= shellEscape(k ~ "=" ~ get[k]); }
+    return(args);
+  }
   final @property string    params() const {
       Appender!string str; 
       foreach(k; get.byKey()){ str.put(format(" %s", shellEscape(k ~ "=" ~ get[k]))); }

--- a/danode/request.d
+++ b/danode/request.d
@@ -3,7 +3,7 @@ module danode.request;
 import danode.imports;
 import danode.filesystem : FileSystem;
 import danode.interfaces : ClientInterface, DriverInterface;
-import danode.functions : interpreter, from, parseHtmlDate, shellEscape;
+import danode.functions : interpreter, from, parseHtmlDate, parseQueryString, shellEscape;
 import danode.webconfig : WebConfig;
 import danode.http : HTTP;
 import danode.post : PostItem, PostType;
@@ -135,11 +135,7 @@ struct Request {
   }
 
   // Get parameters as associative array
-  final string[string] get() const {
-    string[string] params;
-    foreach(param; query[1 .. $].split("&")){ string[] elems = param.split("="); if(elems.length == 1){ elems ~= "TRUE"; } params[elems[0]] = elems[1]; }
-    return params;
-  }
+  final string[string] get() const { return parseQueryString(query[1 .. $], "TRUE"); }
 
   // List of filenames uploaded by the user
   final @property string[]  postfiles() const { 

--- a/danode/response.d
+++ b/danode/response.d
@@ -119,26 +119,6 @@ struct Response {
   @property final bool ready(bool r = false){ if(r){ routed = r; } return(routed && payload.ready()); }
 }
 
-// parse a HTTPresponse header from an external script
-char[] parseHTTPResponseHeader(ref Response response, CGI script, HeaderType type, long clength) {
-  if (type == HeaderType.FastCGI) {
-    // FastCGI type header, create response line on Status: indicator
-    string status = script.getHeader("Status", "500 Internal Server Error");
-    response.hdr.put(format("%s %s\n", "HTTP/1.1", status));
-  }
-
- /* foreach (line; script.fullHeader().split("\n")) { 
-    auto v = line.split(": ");
-    response.headers[v[0]] = v[1];
-  } */
-  response.hdr.put(script.fullHeader());
-  info("script: status: %d, eoh: %d, content: %d", script.statuscode, script.endOfHeader(), clength);
-  response.connection = strip(script.getHeader("Connection", "Close"));
-  info("connection: %s -> %s, to %s in %d bytes", strip(script.getHeader("Connection", "Close")), response.connection, type, response.hdr.data.length);
-  response.cgiheader = true;
-  return(response.hdr.data);
-}
-
 // create a standard response
 Response create(in Request request, Address address, in StatusCode statuscode = StatusCode.Ok, in string mimetype = UNSUPPORTED_FILE){
   Response response = Response(request.protocol);

--- a/danode/response.d
+++ b/danode/response.d
@@ -36,7 +36,7 @@ struct Response {
 
   final void customheader(string key, string value) nothrow { headers[key] = value; }
 
-  // Generate a HTML header for the response
+  // Generate a HTTP header for the response
   @property final char[] header() {
     if (hdr.data) {
       return(hdr.data); // Header was constructed

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -38,8 +38,7 @@ version(SSL) {
 
   extern (C)
   {
-    __gshared int             ncontext;         // How many contexts are available
-    __gshared SSLcontext*     contexts;         // SSL / HTTPs contexts (allocated globally from C)
+    __gshared SSLcontext[]    contexts;         // SSL / HTTPs contexts (allocated globally from C)
 
     // C callback function to switch SSL contexts after hostname lookup
     static void switchContext(SSL* ssl, int *ad, void *arg) {
@@ -50,7 +49,7 @@ version(SSL) {
         return;
       }
       string s;
-      for(int x = 0; x < ncontext; x++) {
+      for(int x = 0; x < contexts.length; x++) {
         s = to!string(contexts[x].hostname.ptr);
         custom(1, "HTTPS", "context: %s %s", hostname, s);
         if(hostname.endsWith(s)) {
@@ -88,7 +87,7 @@ version(SSL) {
   bool hasCertificate(string hostname) {
     custom(1, "HTTPS", "'%s' certificate?", hostname);
     string s;
-    for(size_t x = 0; x < ncontext; x++) {
+    for(size_t x = 0; x < contexts.length; x++) {
       s = to!string(contexts[x].hostname.ptr);
       if(hostname.endsWith(s)) {
         custom(1, "HTTPS", "'%s' certificate found", hostname);
@@ -139,29 +138,17 @@ version(SSL) {
   }
 
   // loads all crt files in the certDir, using keyfile: server.key
-  SSLcontext* initSSL(Server server, string certDir = ".ssl/", string keyFile = ".ssl/server.key", VERSION v = SSL23) {
+  void initSSL(Server server, string certDir = ".ssl/", string keyFile = ".ssl/server.key", VERSION v = SSL23) {
     custom(0, "HTTPS", "loading Deimos.openSSL, certDir: %s, keyFile: %s, SSL:%s", certDir, keyFile, v);
     SSL_library_init();
     OpenSSL_add_all_algorithms();
     SSL_load_error_strings();
-    contexts = cast(SSLcontext*) malloc(0 * SSLcontext.sizeof);
     custom(0, "HTTPS", "certificate folder: %d", exists(certDir));
-    if (!exists(certDir)) {
-      warning("SSL certificate folder '%s' not found", certDir);
-      return contexts;
-    }
-    if (!isDir(certDir)) {
-      warning("SSL certificate folder '%s' not a folder", certDir);
-      return contexts;
-    }
-    if (!exists(keyFile)) {
-      warning("SSL private key file: '%s' not found", certDir);
-      return contexts;
-    }
-    if (!isFile(keyFile)) {
-      warning("SSL private key file: '%s' not a file", certDir);
-      return contexts;
-    }
+
+    if (!exists(certDir)) { warning("SSL certificate folder '%s' not found", certDir); return; }
+    if (!isDir(certDir)) { warning("SSL certificate folder '%s' not a folder", certDir); return; }
+    if (!exists(keyFile)) { warning("SSL private key file: '%s' not found", certDir); return; }
+    if (!isFile(keyFile)) { warning("SSL private key file: '%s' not a file", certDir); return; }
 
     foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
       if (d.name.endsWith(".crt")) {
@@ -172,34 +159,25 @@ version(SSL) {
             writefln("[INFO]   loading certificate from file: %s", d.name);
             writefln("[INFO]   loading chain from file: %s", chainFile);
           }
-          contexts = cast(SSLcontext*) realloc(contexts, (ncontext+1) * SSLcontext.sizeof);
-          contexts[ncontext] = loadContext(d.name, hostname, keyFile, chainFile);
-          custom(1, "HTTPS", "stored certificate: %s in context: %d", to!string(contexts[ncontext].hostname.ptr), ncontext);
-          ncontext++;
+          contexts ~= loadContext(d.name, hostname, keyFile, chainFile);
+          custom(1, "HTTPS", "stored certificate: %s in context: %d", to!string(contexts[$-1].hostname.ptr), contexts.length-1);
         }
       }
     }
-    custom(0, "HTTPS", "loaded %s SSL certificates", ncontext);
-    return contexts;
+    custom(0, "HTTPS", "loaded %s SSL certificates", contexts.length);
   }
 
   // Close the server SSL socket, and clean up the different contexts
   void closeSSL(Socket socket) {
     custom(1, "HTTPS", "closing server SSL socket");
     socket.close();
-    custom(1, "HTTPS", "cleaning up %d HTTPS contexts", ncontext);
-    for(int x = 0; x < ncontext; x++) {
-      // Free the different SSL contexts
-      SSL_CTX_free(contexts[x].context);
-    }
-    free(contexts);
+    custom(1, "HTTPS", "cleaning up %d HTTPS contexts", contexts.length);
+    foreach (ref ctx; contexts) { SSL_CTX_free(ctx.context); }
+    contexts = null;
   }
 
   void sslAssert(bool ret) { 
-    if (!ret) {
-      ERR_print_errors_fp(stderr.getFP());
-      throw new Exception("SSL_ERROR");
-    }
+    if (!ret) { ERR_print_errors_fp(stderr.getFP()); throw new Exception("SSL_ERROR"); }
   }
 
   unittest {

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -66,16 +66,14 @@ struct WebConfig {
   // Is the directory allowed to be viewed ?
   @property bool dirAllowed(in string localroot, in string path) const {
     trace("dirAllowed: %s %s", localroot, path);
+    if (path.length <= localroot.length + 1) return true; // root dir always allowed
     string npath = path[(localroot.length + 1) .. $];
     trace("npath: %s", npath);
-    if (npath == "") // path / is always allowed
-      return(true);
-
     foreach (d; allowdirs) {
       trace("%s in allowdirs: %s %s", npath, d, npath.indexOf(d));
-      if(indexOf(strip(npath), strip(d)) == 0) return(true);
+      if (indexOf(strip(npath), strip(d)) == 0) return true;
     }
-    return(false);
+    return false;
   }
 }
 

--- a/sh/run
+++ b/sh/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 rm -rf server.log
-nohup authbind danode/server -k -b 100 -v 2 > server.log 2>&1 &
+nohup authbind danode/server -k -b 100 -v 0 > server.log 2>&1 &
 


### PR DESCRIPTION

## Security
- **`spawnShell` → `spawnProcess`** — CGI args passed directly to `execve`, eliminating shell injection. `request.command()` now returns `string[]`
- **`safePath()` symlink check** — resolves paths with `buildNormalizedPath`/`absolutePath` and verifies they stay within webroot
- **URL decoding** — `get()` and `parseXform()` now call `decodeComponent()` on keys and values via shared `parseQueryString()` helper; fixes base64 value truncation
- **Unified request size limit** — `MAX_UPLOAD_SIZE` was dead code (10MB socket limit fired first); now a single `MAX_REQUEST_SIZE = 100MB` in `client.d`
 
## Robustness
- **`filesystem.file()` domain guard** — prevents `RangeError` on unregistered domains
- **`FileSystem` root resolved at startup** — eliminates CWD-dependent path resolution on every request
- **`parseMultipart` bounds checking** — all array accesses guarded; `extractQuoted()` and `findBodyLine()` helpers replace magic offset slicing
- **`parseHeader` CRLF normalisation** — `\r\n` normalised before splitting rather than relying on `strip()` side effects
- **`webconfig.dirAllowed` slice guard** — fixes `ArraySliceError` on root directory requests
- **`process.d` exception handling** — `completed = true` now set in catch block, preventing 408 on `spawnProcess` failure
 
## Bug Fixes
- **`monthToIndex` off-by-one** — loop was `x < 12`, December unreachable; fixed to `x <= 12`
 
## Cleanup
- Removed dead code: `parseHTTPResponseHeader()`, `params()`, `shellEscape`
- **SSL** — `malloc`/`realloc`/`free` + manual `ncontext` counter replaced with `SSLcontext[]`
- **`uri` vs `url` comments** — clarified that `uri` is never modified post-parse; `url` is the routing working copy
 