### PR TITLE
Development into master

### DIFF
--- a/danode/cgi.d
+++ b/danode/cgi.d
@@ -109,7 +109,7 @@ class CGI : Payload {
 
     // Stream of message bytes, skips the script generated header since the webserver 
     // parses the header and generates it's own
-    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536) {
+    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) {
       if (endOfHeader > 0) from += bodyStart;
       return(external.output(from)[0 .. to!ptrdiff_t(min(from+maxsize, $))]);
     }

--- a/danode/cgi.d
+++ b/danode/cgi.d
@@ -109,7 +109,7 @@ class CGI : Payload {
 
     // Stream of message bytes, skips the script generated header since the webserver 
     // parses the header and generates it's own
-    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024) {
+    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) {
       if (endOfHeader > 0) from += bodyStart;
       return(external.output(from)[0 .. to!ptrdiff_t(min(from+maxsize, $))]);
     }

--- a/danode/cgi.d
+++ b/danode/cgi.d
@@ -109,7 +109,7 @@ class CGI : Payload {
 
     // Stream of message bytes, skips the script generated header since the webserver 
     // parses the header and generates it's own
-    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) {
+    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536) {
       if (endOfHeader > 0) from += bodyStart;
       return(external.output(from)[0 .. to!ptrdiff_t(min(from+maxsize, $))]);
     }

--- a/danode/cgi.d
+++ b/danode/cgi.d
@@ -109,7 +109,7 @@ class CGI : Payload {
 
     // Stream of message bytes, skips the script generated header since the webserver 
     // parses the header and generates it's own
-    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) {
+    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 4096, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) {
       if (endOfHeader > 0) from += bodyStart;
       return(external.output(from)[0 .. to!ptrdiff_t(min(from+maxsize, $))]);
     }

--- a/danode/client.d
+++ b/danode/client.d
@@ -113,6 +113,10 @@ class Client : Thread, ClientInterface {
 unittest {
   custom(0, "FILE", "%s", __FILE__);
   auto router = new Router("./www/", Address.init, NORMAL);
+
+  router.runRequest("GET /test.pdf HTTP/1.1\nHost: localhost\nRange: bytes=0-65535\n\n");
+  router.runRequest("GET /test.pdf HTTP/1.1\nHost: localhost\nRange: bytes=32517-\n\n");
+
   router.runRequest("GET /dmd.d HTTP/1.1\nHost: localhost\n\n");
   router.runRequest("GET /dmd.d HTTP/1.1\nHost: localhost\r\n\r\n");
   router.runRequest("GET /dmd.d HTTP/1.1\nHost: www.localhost\n\n");

--- a/danode/client.d
+++ b/danode/client.d
@@ -51,9 +51,11 @@ class Client : Thread, ClientInterface {
             }
           }
           if (response.ready && !response.completed) {      // We know what to respond, but haven't send all of it yet
+            custom(1, "CLIENT", "sending: index=%d length=%d isRange=%s", response.index, response.length, response.isRange);
             driver.send(response, driver.socket, 65536);           // Send the response, hit multiple times, send what you can and return
           }
           if (response.ready && response.completed) {       // We've completed the request, response cycle
+            custom(1, "CLIENT", "completed: index=%d length=%d", response.index, response.length);
             router.logRequest(this, request, response);     // Log the response to the request
             request.clearUploadFiles();                     // Clean uploaded files
             request.destroy();                              // Clear the request structure
@@ -63,6 +65,7 @@ class Client : Thread, ClientInterface {
             response.destroy();                             // Clear the response structure
           }
           if (lastmodified >= maxtime) { // Client are not allowed to be silent for more than maxtime
+            custom(1, "CLIENT", "timeout: index=%d length=%d completed=%s", response.index, response.length, response.completed);
             custom(2, "CLIENT", "inactivity: %s > %s", lastmodified, maxtime);
             if (!response.ready && request !is Request.init) { // We have an unhandled request
               driver.setTimedOut(response);

--- a/danode/client.d
+++ b/danode/client.d
@@ -51,11 +51,11 @@ class Client : Thread, ClientInterface {
             }
           }
           if (response.ready && !response.completed) {      // We know what to respond, but haven't send all of it yet
-            custom(1, "CLIENT", "sending: index=%d length=%d isRange=%s", response.index, response.length, response.isRange);
+            //custom(1, "CLIENT", "sending: index=%d length=%d isRange=%s", response.index, response.length, response.isRange);
             driver.send(response, driver.socket, 65536);           // Send the response, hit multiple times, send what you can and return
           }
           if (response.ready && response.completed) {       // We've completed the request, response cycle
-            custom(1, "CLIENT", "completed: index=%d length=%d", response.index, response.length);
+            //custom(1, "CLIENT", "completed: index=%d length=%d", response.index, response.length);
             router.logRequest(this, request, response);     // Log the response to the request
             request.clearUploadFiles();                     // Clean uploaded files
             request.destroy();                              // Clear the request structure
@@ -65,7 +65,7 @@ class Client : Thread, ClientInterface {
             response.destroy();                             // Clear the response structure
           }
           if (lastmodified >= maxtime) { // Client are not allowed to be silent for more than maxtime
-            custom(1, "CLIENT", "timeout: index=%d length=%d completed=%s", response.index, response.length, response.completed);
+            //custom(1, "CLIENT", "timeout: index=%d length=%d completed=%s", response.index, response.length, response.completed);
             custom(2, "CLIENT", "inactivity: %s > %s", lastmodified, maxtime);
             if (!response.ready && request !is Request.init) { // We have an unhandled request
               driver.setTimedOut(response);

--- a/danode/client.d
+++ b/danode/client.d
@@ -52,7 +52,7 @@ class Client : Thread, ClientInterface {
           }
           if (response.ready && !response.completed) {      // We know what to respond, but haven't send all of it yet
             //custom(1, "CLIENT", "sending: index=%d length=%d isRange=%s", response.index, response.length, response.isRange);
-            driver.send(response, driver.socket, 65536);           // Send the response, hit multiple times, send what you can and return
+            driver.send(response, driver.socket);           // Send the response, hit multiple times, send what you can and return
           }
           if (response.ready && response.completed) {       // We've completed the request, response cycle
             //custom(1, "CLIENT", "completed: index=%d length=%d", response.index, response.length);

--- a/danode/client.d
+++ b/danode/client.d
@@ -74,7 +74,7 @@ class Client : Thread, ClientInterface {
             stop(); continue;
           }
           custom(3, "CLIENT", "connection %s:%s (%s msecs) %s", ip, port, starttime, to!string(driver.inbuffer.data));
-          Thread.yield();
+          Thread.sleep(dur!"msecs"(2));
         }
       } catch(Exception e) { 
         warning("Unknown Client Exception: %s", e);

--- a/danode/client.d
+++ b/danode/client.d
@@ -49,18 +49,18 @@ class Client : Thread, ClientInterface {
               // Parse the data and try to create a response (Could fail multiple times)
               router.route(driver, request, response, maxtime);
             }
-            if (response.ready && !response.completed) {      // We know what to respond, but haven't send all of it yet
-              driver.send(response, driver.socket, 65536);           // Send the response, hit multiple times, send what you can and return
-            }
-            if (response.ready && response.completed) {       // We've completed the request, response cycle
-              router.logRequest(this, request, response);     // Log the response to the request
-              request.clearUploadFiles();                     // Clean uploaded files
-              request.destroy();                              // Clear the request structure
-              driver.inbuffer.destroy();                      // Clear the input buffer
-              driver.requests++;
-              if(!response.keepalive) stop();                 // No keep alive, then stop this client
-              response.destroy();                             // Clear the response structure
-            }
+          }
+          if (response.ready && !response.completed) {      // We know what to respond, but haven't send all of it yet
+            driver.send(response, driver.socket, 65536);           // Send the response, hit multiple times, send what you can and return
+          }
+          if (response.ready && response.completed) {       // We've completed the request, response cycle
+            router.logRequest(this, request, response);     // Log the response to the request
+            request.clearUploadFiles();                     // Clean uploaded files
+            request.destroy();                              // Clear the request structure
+            driver.inbuffer.destroy();                      // Clear the input buffer
+            driver.requests++;
+            if(!response.keepalive) stop();                 // No keep alive, then stop this client
+            response.destroy();                             // Clear the response structure
           }
           if (lastmodified >= maxtime) { // Client are not allowed to be silent for more than maxtime
             custom(2, "CLIENT", "inactivity: %s > %s", lastmodified, maxtime);

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -108,12 +108,12 @@ unittest {
   custom(0, "FILE", "%s", __FILE__);
   Log logger = new Log(NORMAL);
   FileSystem filesystem = new FileSystem(logger, "./www/");
-  custom(0, "TEST", "./www/localhost/dmd.d (6 bytes) = %s", filesystem.file("./www/localhost", "/dmd.d").bytes(0,6));
+  custom(0, "TEST", "./www/localhost/dmd.d (6 bytes) = %s", filesystem.file(filesystem.localroot("localhost"), "/dmd.d").bytes(0,6));
   custom(0, "TEST", "filesystem.localroot('localhost') = %s", filesystem.localroot("localhost"));
   Domain localhost = filesystem.scan("www/localhost");
   custom(0, "TEST", "localhost.buffersize() = %s", localhost.buffersize());
   custom(0, "TEST", "localhost.size() = %s", localhost.size());
-  auto file = filesystem.file(filesystem.localroot("localhost"), "localhost/dmd.d");
+  auto file = filesystem.file(filesystem.localroot("localhost"), "/dmd.d");
   custom(0, "TEST", "file.asStream(0) = %s", file.asStream(0));
   custom(0, "TEST", "file.statuscode() = %s", file.statuscode());
   custom(0, "TEST", "file.mimetype() = %s", file.mimetype());

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -31,7 +31,8 @@ class FileSystem {
   public:
     this(Log logger, string root = "./www/", size_t maxsize = 1024 * 512){
       this.logger   = logger;
-      this.root = buildNormalizedPath(absolutePath(root)) ~ "/";
+      this.root = buildNormalizedPath(absolutePath(root)).replace("\\", "/");
+      if (!this.root.endsWith("/")) this.root ~= "/";
       this.maxsize  = maxsize;
       scan();
     }

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -180,8 +180,10 @@ string browseDir(in string root, in string localpath) {
   Appender!(string) content;
   content.put(format("Content of: %s<br>\n", htmlEscape(localpath)));
   foreach (DirEntry d; dirEntries(localpath, SpanMode.shallow)) {
-      string name = htmlEscape(d.name[root.length .. $]);
-      content.put(format("<a href='%s'>%s</a><br>", name, name));
+    string name = d.name[root.length .. $].replace("\\", "/");
+    if (name.endsWith(".in") || name.endsWith(".up")) continue;
+    string escaped = htmlEscape(name);
+    content.put(format("<a href='%s'>%s</a><br>", escaped, escaped));
   }
   return(format("<html><head><title>200 - Allowed directory</title></head><body>%s</body></html>", content.data));
 }

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -35,17 +35,17 @@ pure string htmlEscape(string s) {
 
 // Returns null if path escapes root
 string safePath(in string root, in string path) {
-  if (path.canFind("..")) return null;
-  if (path.canFind("\0")) return null;
-  string full = root ~ (path.startsWith("/") ? path : "/" ~ path);
-  try {
-    if (exists(full)) {
-      string absroot  = buildNormalizedPath(absolutePath(root));
-      string resolved = buildNormalizedPath(absolutePath(full));
-      if (resolved != absroot && !resolved.startsWith(absroot ~ "/")) return null;
-    }
-  } catch (Exception e) { return null; }
-  return full;
+    if (path.canFind("..")) return null;
+    if (path.canFind("\0")) return null;
+    string full = root ~ (path.startsWith("/") ? path : "/" ~ path);
+    try {
+        if (exists(full)) {
+            string resolved = buildNormalizedPath(absolutePath(full)).replace("\\", "/");
+            string absroot  = root.endsWith("/") ? root : root ~ "/";
+            if (resolved != absroot[0..$-1] && !resolved.startsWith(absroot)) return null;
+        }
+    } catch (Exception e) { return null; }
+    return full;
 }
 
 // Month to index of the year

--- a/danode/http.d
+++ b/danode/http.d
@@ -45,20 +45,21 @@ class HTTP : DriverInterface {
     }
 
     // Send upto maxsize bytes from the response to the client
-    override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096)  { synchronized {
+    override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096) { synchronized {
       if(socket is null) return;
       if(!socket.isAlive()) return;
+      // Wait until socket is writable before sending
+      SocketSet writeSet = new SocketSet();
+      writeSet.add(socket);
+      if (Socket.select(null, writeSet, null, dur!"msecs"(100)) <= 0) return;
       ptrdiff_t send = socket.send(response.bytes(maxsize));
       custom(1, "HTTP", "send result=%d index=%d length=%d", send, response.index, response.length);
-      if (send >= 0) {
-        if (send > 0) modtime = Clock.currTime();
-        response.index += send; senddata[requests] += send;
-        if(response.index >= response.length) response.completed = true;
-      }else if (send == -1) { // send buffer full, back off
+      if (send > 0) {
         modtime = Clock.currTime();
-        Thread.sleep(dur!"msecs"(2));
+        response.index += send;
+        senddata[requests] += send;
+        if(response.index >= response.length) response.completed = true;
       }
-      if(send > 0) custom(3, "HTTP", "send %d bytes of data", send);
     } }
 
     // Close the connection, by shutting down the socket

--- a/danode/http.d
+++ b/danode/http.d
@@ -54,9 +54,9 @@ class HTTP : DriverInterface {
         if (send > 0) modtime = Clock.currTime();
         response.index += send; senddata[requests] += send;
         if(response.index >= response.length) response.completed = true;
-      }else if (send == -1) {
-        // send buffer full, back off
-        Thread.sleep(dur!"msecs"(10));
+      }else if (send == -1) { // send buffer full, back off
+        modtime = Clock.currTime();
+        Thread.sleep(dur!"msecs"(2));
       }
       if(send > 0) custom(3, "HTTP", "send %d bytes of data", send);
     } }

--- a/danode/http.d
+++ b/danode/http.d
@@ -51,7 +51,7 @@ class HTTP : DriverInterface {
       // Wait until socket is writable before sending
       SocketSet writeSet = new SocketSet();
       writeSet.add(socket);
-      if (Socket.select(null, writeSet, null, dur!"msecs"(100)) <= 0) return;
+      if (Socket.select(null, writeSet, null, dur!"msecs"(0)) <= 0) return;
       ptrdiff_t send = socket.send(response.bytes(maxsize));
       custom(1, "HTTP", "send result=%d index=%d length=%d", send, response.index, response.length);
       if (send > 0) {

--- a/danode/http.d
+++ b/danode/http.d
@@ -54,6 +54,9 @@ class HTTP : DriverInterface {
         if (send > 0) modtime = Clock.currTime();
         response.index += send; senddata[requests] += send;
         if(response.index >= response.length) response.completed = true;
+      }else if (send == -1) {
+        // send buffer full, back off
+        Thread.sleep(dur!"msecs"(10));
       }
       if(send > 0) custom(3, "HTTP", "send %d bytes of data", send);
     } }

--- a/danode/http.d
+++ b/danode/http.d
@@ -49,6 +49,7 @@ class HTTP : DriverInterface {
       if(socket is null) return;
       if(!socket.isAlive()) return;
       ptrdiff_t send = socket.send(response.bytes(maxsize));
+      custom(1, "HTTP", "send result=%d index=%d length=%d", send, response.index, response.length);
       if (send >= 0) {
         if (send > 0) modtime = Clock.currTime();
         response.index += send; senddata[requests] += send;

--- a/danode/https.d
+++ b/danode/https.d
@@ -150,6 +150,8 @@ version(SSL) {
           response.index += send;
           senddata[requests] += send;
           if(response.index >= response.length) response.completed = true;
+        }else if (response.ready && !response.completed) {
+          modtime = Clock.currTime(); // mid-transfer SSL backpressure, not idle
         }
       } }
 

--- a/danode/https.d
+++ b/danode/https.d
@@ -145,6 +145,9 @@ version(SSL) {
           if(send > 0) modtime = Clock.currTime();
           response.index += send; senddata[requests] += send;
           if(response.index >= response.length) response.completed = true;
+        }else if (send == -1) { // send buffer full, back off
+          modtime = Clock.currTime();
+          Thread.sleep(dur!"msecs"(2));
         }
         if(send > 0) custom(3, "HTTPS", "send %d bytes of data", send);
       } }

--- a/danode/https.d
+++ b/danode/https.d
@@ -138,18 +138,19 @@ version(SSL) {
         if(socket is null) return;
         if(!socket.isAlive()) return;
         if(ssl is null) return;
-
+        // Wait until socket is writable before sending
+        SocketSet writeSet = new SocketSet();
+        writeSet.add(socket);
+        if (Socket.select(null, writeSet, null, dur!"msecs"(100)) <= 0) return;
         auto slice = response.bytes(maxsize);
         ptrdiff_t send = SSL_write(ssl, cast(void*) slice, cast(int) slice.length);
-        if(send >= 0) {
-          if(send > 0) modtime = Clock.currTime();
-          response.index += send; senddata[requests] += send;
-          if(response.index >= response.length) response.completed = true;
-        }else if (send == -1) { // send buffer full, back off
+        custom(1, "HTTPS", "send result=%d index=%d length=%d", send, response.index, response.length);
+        if (send > 0) {
           modtime = Clock.currTime();
-          Thread.sleep(dur!"msecs"(2));
+          response.index += send;
+          senddata[requests] += send;
+          if(response.index >= response.length) response.completed = true;
         }
-        if(send > 0) custom(3, "HTTPS", "send %d bytes of data", send);
       } }
 
       @nogc override bool isSecure() const nothrow { return(true); }

--- a/danode/https.d
+++ b/danode/https.d
@@ -14,6 +14,7 @@ version(SSL) {
 
   class HTTPS : DriverInterface {
     private:
+      char[] pending;
       SSL* ssl = null;
 
     public:
@@ -138,21 +139,20 @@ version(SSL) {
         if(socket is null) return;
         if(!socket.isAlive()) return;
         if(ssl is null) return;
-        // Wait until socket is writable before sending
-        SocketSet writeSet = new SocketSet();
-        writeSet.add(socket);
-        if (Socket.select(null, writeSet, null, dur!"msecs"(100)) <= 0) return;
-        auto slice = response.bytes(maxsize);
-        ptrdiff_t send = SSL_write(ssl, cast(void*) slice, cast(int) slice.length);
+        // SSL requires retrying with exact same buffer on WANT_WRITE
+        if (pending.length == 0) pending = response.bytes(maxsize).dup;
+        if (pending.length == 0) return;
+        ptrdiff_t send = SSL_write(ssl, cast(void*) pending.ptr, cast(int) pending.length);
         custom(1, "HTTPS", "send result=%d index=%d length=%d", send, response.index, response.length);
         if (send > 0) {
           modtime = Clock.currTime();
           response.index += send;
           senddata[requests] += send;
           if(response.index >= response.length) response.completed = true;
-        }else if (response.ready && !response.completed) {
-          modtime = Clock.currTime(); // mid-transfer SSL backpressure, not idle
+          pending = [];  // clear on success, fetch next chunk next call
         }
+        // on send <= 0: keep pending, retry same buffer next call
+        // modtime not updated — inactivity timeout still works for dead connections
       } }
 
       @nogc override bool isSecure() const nothrow { return(true); }

--- a/danode/imports.d
+++ b/danode/imports.d
@@ -13,7 +13,7 @@ public import std.conv : to;
 public import std.datetime : dur, msecs;
 public import std.getopt : getopt;
 public import std.path : baseName, extension, absolutePath, buildNormalizedPath;
-public import std.process : pipe, spawnProcess, tryWait, wait, kill;
+public import std.process : pipe, executeShell, spawnProcess, tryWait, wait, kill;
 public import std.file : dirEntries, exists, remove, isFile, isDir, timeLastModified, getSize;
 public import std.format : format, formatValue;
 public import std.regex : regex, match;

--- a/danode/log.d
+++ b/danode/log.d
@@ -113,7 +113,7 @@ class Log {
       if (cverbose >= NOTSET) {
         string uri;
         try { uri = decodeComponent(rq.uri); } catch (Exception e) { uri = rq.uri; }
-        string s = format("[%d]    %s %s:%s %s%s %s %s", rs.statuscode, htmltime(), cl.ip, cl.port, rq.shorthost, uri, Msecs(rq.starttime), rs.payload.length);
+        string s = format("[%d]    %s %s:%s %s%s %s %s", rs.statuscode, htmltime(), cl.ip, cl.port, rq.shorthost, uri, Msecs(rq.starttime), rs.isRange ? (rs.rangeEnd - rs.rangeStart + 1) : rs.payload.length);
         RequestLogFp.writeln(s);
         custom(-1, "REQ", s);
         RequestLogFp.flush();

--- a/danode/log.d
+++ b/danode/log.d
@@ -111,7 +111,9 @@ class Log {
     // Log the responses to the request
     void logRequest(in ClientInterface cl, in Request rq, in Response rs) {
       if (cverbose >= NOTSET) {
-        string s = format("[%d]    %s %s:%s %s%s %s %s", rs.statuscode, htmltime(), cl.ip, cl.port, rq.shorthost, decodeComponent(rq.uri), Msecs(rq.starttime), rs.payload.length);
+        string uri;
+        try { uri = decodeComponent(rq.uri); } catch (Exception e) { uri = rq.uri; }
+        string s = format("[%d]    %s %s:%s %s%s %s %s", rs.statuscode, htmltime(), cl.ip, cl.port, rq.shorthost, uri, Msecs(rq.starttime), rs.payload.length);
         RequestLogFp.writeln(s);
         custom(-1, "REQ", s);
         RequestLogFp.flush();

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -131,7 +131,7 @@ class FilePayload : Payload {
     /* Files are always assumed ready to be handled (unlike Common Gate Way threads)  */
     final @property long ready() { return(true); }
     /* Payload type delivered to the client  */
-    final @property PayloadType type() const { return(PayloadType.Message); }
+    final @property PayloadType type() const { return(PayloadType.File); }
     /* Size of the file, -1 if it does not exist  */
     final @property ptrdiff_t fileSize() const { if(!realfile){ return -1; } return to!ptrdiff_t(path.getSize()); }
     /* Length of the buffer  */

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -19,7 +19,7 @@ interface Payload {
     @property SysTime             mtime();
     @property string              mimetype() const;
 
-    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024);
+    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1);
 }
 
 /* Implementation of the Payload interface, by using an empty string message */
@@ -50,7 +50,7 @@ class Message : Payload {
     final @property SysTime mtime() { return Clock.currTime(); }
     final @property string mimetype() const { return mime; }
     final @property StatusCode statuscode() const { return status; }
-    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 1024) { 
+    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) { 
       return( message[from .. to!ptrdiff_t(min(from+maxsize, $))].dup );
     }
 }
@@ -59,9 +59,7 @@ class Message : Payload {
 class FilePayload : Payload {
   public:
     bool      deflate = false; // Is a deflate version of the file available ?
-    bool      isRange = false;
-    long      rangeStart = 0;
-    long      rangeEnd = -1;
+
   private:
     string    path; // Path of the file
     SysTime   btime; // Time buffered
@@ -142,12 +140,10 @@ class FilePayload : Payload {
     final @property string mimetype() const { return mime(path); }
     /* Status code for file is StatusCode.Ok ? */
     final @property StatusCode statuscode() const { 
-      if (!realfile) return StatusCode.NotFound;
-      return isRange ? StatusCode.PartialContent : StatusCode.Ok; 
+      return realfile ? StatusCode.Ok : StatusCode.NotFound; 
     }
     /* Get the number of bytes that the client response has, based on encoding */
     final @property ptrdiff_t length() const {
-      if (isRange) return to!ptrdiff_t(rangeEnd - rangeStart + 1);
       if(hasEncodedVersion && deflate) return(encbuf.length);
       return(fileSize());
     }
@@ -178,14 +174,15 @@ class FilePayload : Payload {
     }
 
     /* Get bytes in a lockfree manner from the correct underlying buffer */
-    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536){ synchronized {
+    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, 
+                              bool isRange = false, long rangeStart = 0, long rangeEnd = -1){ synchronized {
       if (!realfile) { return []; }
-      trace("file provided is a real file");
       if (needsupdate) { buffer(); }
       ptrdiff_t offset = isRange? to!ptrdiff_t(rangeStart) + from : from;
       ptrdiff_t limit = isRange? to!ptrdiff_t(rangeEnd - rangeStart + 1) : -1;
       ptrdiff_t sz = (limit > 0)? to!ptrdiff_t(min(maxsize, max(0, limit - from))) : maxsize;
-      trace("range: start=%d end=%d from=%d offset=%d sz=%d limit=%d", rangeStart, rangeEnd, from, offset, sz, limit);
+      info("bytes: isRange=%s rangeStart=%d rangeEnd=%d from=%d offset=%d sz=%d limit=%d", 
+          isRange, rangeStart, rangeEnd, from, offset, sz, limit);
       if (!buffered) {
         return(asStream(offset, sz));
       } else {

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -181,7 +181,7 @@ class FilePayload : Payload {
       ptrdiff_t offset = isRange? to!ptrdiff_t(rangeStart) + from : from;
       ptrdiff_t limit = isRange? to!ptrdiff_t(rangeEnd - rangeStart + 1) : -1;
       ptrdiff_t sz = (limit > 0)? to!ptrdiff_t(min(maxsize, max(0, limit - from))) : maxsize;
-      info("bytes: isRange=%s rangeStart=%d rangeEnd=%d from=%d offset=%d sz=%d limit=%d", 
+      custom(1, "CLIENT", "bytes: isRange=%s rangeStart=%d rangeEnd=%d from=%d offset=%d sz=%d limit=%d", 
           isRange, rangeStart, rangeEnd, from, offset, sz, limit);
       if (!buffered) {
         return(asStream(offset, sz));

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -19,7 +19,7 @@ interface Payload {
     @property SysTime             mtime();
     @property string              mimetype() const;
 
-    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1);
+    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 4096, bool isRange = false, long rangeStart = 0, long rangeEnd = -1);
 }
 
 /* Implementation of the Payload interface, by using an empty string message */
@@ -50,7 +50,7 @@ class Message : Payload {
     final @property SysTime mtime() { return Clock.currTime(); }
     final @property string mimetype() const { return mime; }
     final @property StatusCode statuscode() const { return status; }
-    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) {
+    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 4096, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) {
       return( message[from .. to!ptrdiff_t(min(from+maxsize, $))].dup );
     }
 }
@@ -149,7 +149,7 @@ class FilePayload : Payload {
     }
 
     /* Send the file from the underlying raw byte source stream using fseek, fp are closed */
-    final char[] asStream(ptrdiff_t from, ptrdiff_t maxsize = 65536) {
+    final char[] asStream(ptrdiff_t from, ptrdiff_t maxsize = 4096) {
       //custom(1, "STREAM", "asStream: from=%d sz=%d fileSize=%d", from, maxsize, fileSize());
       char[] tmpbuf = new char[](maxsize);
       char[] slice = [];
@@ -175,7 +175,7 @@ class FilePayload : Payload {
     }
 
     /* Get bytes in a lockfree manner from the correct underlying buffer */
-    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) { synchronized {
+    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 4096, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) { synchronized {
       if (!realfile) { return []; }
       if (needsupdate) { buffer(); }
       ptrdiff_t offset = isRange ? to!ptrdiff_t(rangeStart) + from : from;

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -181,7 +181,7 @@ class FilePayload : Payload {
       ptrdiff_t offset = isRange? to!ptrdiff_t(rangeStart) + from : from;
       ptrdiff_t limit = isRange? to!ptrdiff_t(rangeEnd - rangeStart + 1) : -1;
       ptrdiff_t sz = (limit > 0)? to!ptrdiff_t(min(maxsize, max(0, limit - from))) : maxsize;
-      custom(1, "CLIENT", "bytes: isRange=%s rangeStart=%d rangeEnd=%d from=%d offset=%d sz=%d limit=%d", 
+      trace("bytes: isRange=%s rangeStart=%d rangeEnd=%d from=%d offset=%d sz=%d limit=%d", 
           isRange, rangeStart, rangeEnd, from, offset, sz, limit);
       if (!buffered) {
         return(asStream(offset, sz));

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -3,7 +3,7 @@ module danode.payload;
 import danode.imports;
 import danode.statuscode : StatusCode;
 import danode.mimetypes : mime, UNSUPPORTED_FILE;
-import danode.log : info, warning, trace, cverbose, DEBUG;
+import danode.log : custom, info, warning, trace, cverbose, DEBUG;
 import danode.functions : isCGI;
 
 enum PayloadType { Message, Script, File }
@@ -150,6 +150,7 @@ class FilePayload : Payload {
 
     /* Send the file from the underlying raw byte source stream using fseek, fp are closed */
     final char[] asStream(ptrdiff_t from, ptrdiff_t maxsize = 65536) {
+      custom(1, "STREAM", "asStream: from=%d sz=%d fileSize=%d", from, maxsize, fileSize());
       char[] tmpbuf = new char[](maxsize);
       char[] slice = [];
       if (cverbose >= DEBUG && from == 0) write("[STREAM] .");

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -19,7 +19,7 @@ interface Payload {
     @property SysTime             mtime();
     @property string              mimetype() const;
 
-    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1);
+    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536);
 }
 
 /* Implementation of the Payload interface, by using an empty string message */
@@ -50,7 +50,7 @@ class Message : Payload {
     final @property SysTime mtime() { return Clock.currTime(); }
     final @property string mimetype() const { return mime; }
     final @property StatusCode statuscode() const { return status; }
-    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) { 
+    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536) {
       return( message[from .. to!ptrdiff_t(min(from+maxsize, $))].dup );
     }
 }
@@ -150,7 +150,7 @@ class FilePayload : Payload {
 
     /* Send the file from the underlying raw byte source stream using fseek, fp are closed */
     final char[] asStream(ptrdiff_t from, ptrdiff_t maxsize = 65536) {
-      custom(1, "STREAM", "asStream: from=%d sz=%d fileSize=%d", from, maxsize, fileSize());
+      //custom(1, "STREAM", "asStream: from=%d sz=%d fileSize=%d", from, maxsize, fileSize());
       char[] tmpbuf = new char[](maxsize);
       char[] slice = [];
       if (cverbose >= DEBUG && from == 0) write("[STREAM] .");
@@ -175,25 +175,19 @@ class FilePayload : Payload {
     }
 
     /* Get bytes in a lockfree manner from the correct underlying buffer */
-    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, 
-                              bool isRange = false, long rangeStart = 0, long rangeEnd = -1){ synchronized {
-      if (!realfile) { return []; }
-      if (needsupdate) { buffer(); }
-      ptrdiff_t offset = isRange? to!ptrdiff_t(rangeStart) + from : from;
-      ptrdiff_t limit = isRange? to!ptrdiff_t(rangeEnd - rangeStart + 1) : -1;
-      ptrdiff_t sz = (limit > 0)? to!ptrdiff_t(min(maxsize, max(0, limit - from))) : maxsize;
-      trace("bytes: isRange=%s rangeStart=%d rangeEnd=%d from=%d offset=%d sz=%d limit=%d", 
-          isRange, rangeStart, rangeEnd, from, offset, sz, limit);
-      if (!buffered) {
-        return(asStream(offset, sz));
+  final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536) { synchronized {
+    if (!realfile) { return []; }
+    if (needsupdate) { buffer(); }
+    if (!buffered) {
+        return(asStream(from, maxsize));
+    } else {
+      if(hasEncodedVersion && deflate) {
+        if(from < encbuf.length) return( encbuf[from .. to!ptrdiff_t(min(from+maxsize, $))] );
       } else {
-        if(hasEncodedVersion && deflate) {
-          if(offset < encbuf.length) return( encbuf[offset .. to!ptrdiff_t(min(offset+sz, $))] );
-        } else {
-          if(offset < buf.length) return( buf[offset .. to!ptrdiff_t(min(offset+sz, $))] );
-        }
+        if(from < buf.length) return( buf[from .. to!ptrdiff_t(min(from+maxsize, $))] );
       }
-      return([]);
-    } }
+    }
+    return([]);
+  } }
 }
 

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -19,7 +19,7 @@ interface Payload {
     @property SysTime             mtime();
     @property string              mimetype() const;
 
-    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536);
+    const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1);
 }
 
 /* Implementation of the Payload interface, by using an empty string message */
@@ -50,7 +50,7 @@ class Message : Payload {
     final @property SysTime mtime() { return Clock.currTime(); }
     final @property string mimetype() const { return mime; }
     final @property StatusCode statuscode() const { return status; }
-    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536) {
+    char[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) {
       return( message[from .. to!ptrdiff_t(min(from+maxsize, $))].dup );
     }
 }
@@ -175,19 +175,22 @@ class FilePayload : Payload {
     }
 
     /* Get bytes in a lockfree manner from the correct underlying buffer */
-  final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536) { synchronized {
-    if (!realfile) { return []; }
-    if (needsupdate) { buffer(); }
-    if (!buffered) {
-        return(asStream(from, maxsize));
-    } else {
-      if(hasEncodedVersion && deflate) {
-        if(from < encbuf.length) return( encbuf[from .. to!ptrdiff_t(min(from+maxsize, $))] );
+    final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 65536, bool isRange = false, long rangeStart = 0, long rangeEnd = -1) { synchronized {
+      if (!realfile) { return []; }
+      if (needsupdate) { buffer(); }
+      ptrdiff_t offset = isRange ? to!ptrdiff_t(rangeStart) + from : from;
+      ptrdiff_t limit  = isRange ? to!ptrdiff_t(rangeEnd - rangeStart + 1) : -1;
+      ptrdiff_t sz     = (limit > 0) ? to!ptrdiff_t(min(maxsize, max(0, limit - from))) : maxsize;
+      trace("bytes: isRange=%s start=%d end=%d from=%d offset=%d sz=%d", isRange, rangeStart, rangeEnd, from, offset, sz);
+      if (!buffered) {
+        return(asStream(offset, sz));
       } else {
-        if(from < buf.length) return( buf[from .. to!ptrdiff_t(min(from+maxsize, $))] );
+        if(hasEncodedVersion && deflate) {
+          if(offset < encbuf.length) return( encbuf[offset .. to!ptrdiff_t(min(offset+sz, $))] );
+        } else {
+          if(offset < buf.length) return( buf[offset .. to!ptrdiff_t(min(offset+sz, $))] );
+        }
       }
-    }
-    return([]);
-  } }
+      return([]);
+    } }
 }
-

--- a/danode/process.d
+++ b/danode/process.d
@@ -202,7 +202,7 @@ class Process : Thread {
 
 unittest {
   custom(0, "FILE", "%s", __FILE__);
-  auto p = new Process("rdmd www/localhost/dmd.d", "test/dmd.in", false);
+  auto p = new Process(["rdmd", "www/localhost/dmd.d"], "test/dmd.in", false);
   p.start();
   while(!p.finished){ Thread.sleep(msecs(5)); }
   custom(0, "TEST", "status of output: %s", p.status());

--- a/danode/request.d
+++ b/danode/request.d
@@ -86,6 +86,7 @@ struct Request {
       warning("parseHeader exception: %s", e.msg);
       return(false);
     }
+    trace("headers received: %s", this.headers);
     trace("parseHeader %s %s %s, nParams: %d", this.method, this.uri, this.protocol, this.headers.length);
     return(true);
   }

--- a/danode/response.d
+++ b/danode/response.d
@@ -33,9 +33,9 @@ struct Response {
   bool              cgiheader = false;
   Appender!(char[]) hdr;
   ptrdiff_t         index = 0;
-/*  bool              isRange    = false;
+  bool              isRange    = false;
   long              rangeStart = 0;
-  long              rangeEnd   = -1;*/
+  long              rangeEnd   = -1;
 
   final void customheader(string key, string value) nothrow { headers[key] = value; }
 
@@ -90,7 +90,8 @@ struct Response {
     }
     hdr.put(format("Date: %s\r\n", htmltime()));
     if (payload.type != PayloadType.Script && payload.length >= 0) { // If we have any payload
-      hdr.put(format("Content-Length: %d\r\n", payload.length));
+      long contentLength = isRange ? (rangeEnd - rangeStart + 1) : payload.length;
+      hdr.put(format("Content-Length: %d\r\n", contentLength));
       hdr.put(format("Last-Modified: %s\r\n", htmltime(payload.mtime))); // It could be modified long ago, lets inform the client
       if (maxage > 0) { // Perhaps we can have the client cache it (when very old)
         hdr.put(format("Cache-Control: max-age=%d, public\r\n", maxage));
@@ -107,16 +108,23 @@ struct Response {
     if (payload && payload.type == PayloadType.Script) { to!CGI(payload).notifyovertime(); }
   }
 
-  @property final StatusCode statuscode() const { return payload.statuscode; }
+  @property final StatusCode statuscode() const {
+    if (isRange) return StatusCode.PartialContent;
+    return payload.statuscode;
+  }
   @property final bool keepalive() const { return( toLower(connection) == "keep-alive"); }
-  @property final long length() { return header.length + payload.length; }
-  @property final const(char)[] bytes(in ptrdiff_t maxsize = 65536) { // Stream of bytes (header + stream of bytes)
+  @property final long length() {
+    if (isRange) return header.length + (rangeEnd - rangeStart + 1);
+    return header.length + payload.length;
+  }
+  // Stream of bytes (header + stream of bytes)
+  @property final const(char)[] bytes(in ptrdiff_t maxsize = 65536) {
     ptrdiff_t hsize = header.length;
     if(index <= hsize) {  // We haven't completed the header yet
       ptrdiff_t remaining = maxsize - hsize;
-      return(header[index .. hsize] ~ payload.bytes(0, remaining > 0 ? remaining : 0));
+      return(header[index .. hsize] ~ payload.bytes(0, remaining > 0 ? remaining : 0, isRange, rangeStart, rangeEnd));
     }
-    return(payload.bytes(index-hsize, maxsize)); // Header completed, just stream bytes from the payload
+    return(payload.bytes(index-hsize, maxsize, isRange, rangeStart, rangeEnd)); // Header completed, just stream bytes from the payload
   }
 
   @property final bool ready(bool r = false){ if(r){ routed = r; } return(routed && payload.ready()); }
@@ -193,9 +201,9 @@ void serveStaticFile(ref Response response, in Request request, FileSystem fs) {
   }
   response.payload = reqFile;
 
-  //if (request.hasRange) { response.serveRangeFile(request, reqFile); return; }
+  if (request.hasRange) { response.serveRangeFile(request, reqFile); return; }
 
-  //if (!reqFile.deflate) response.customheader("Accept-Ranges", "bytes");
+  if (!reqFile.deflate) response.customheader("Accept-Ranges", "bytes");
   if (request.ifModified >= response.payload.mtime()) {                                        // Non modified static content
     trace("static file has not changed, sending notmodified");
     response.notmodified(request, response.payload.mimetype);
@@ -216,10 +224,11 @@ void serveRangeFile(ref Response response, in Request request, FilePayload reqFi
   } else {
     response.customheader("Content-Range", format("bytes %d-%d/%d", start, end, total));
     response.customheader("Accept-Ranges", "bytes");
-    //response.rangeStart = start;
-   // response.rangeEnd = end;
-   // response.isRange = true;
+    response.rangeStart = start;
+    response.rangeEnd = end;
+    response.isRange = true;
     response.payload = reqFile;
+    trace("serveRangeFile: serving %d bytes", end - start + 1);
   }
   response.ready = true;
 }

--- a/danode/response.d
+++ b/danode/response.d
@@ -33,6 +33,9 @@ struct Response {
   bool              cgiheader = false;
   Appender!(char[]) hdr;
   ptrdiff_t         index = 0;
+  bool              isRange    = false;
+  long              rangeStart = 0;
+  long              rangeEnd   = -1;
 
   final void customheader(string key, string value) nothrow { headers[key] = value; }
 
@@ -104,16 +107,22 @@ struct Response {
     if (payload && payload.type == PayloadType.Script) { to!CGI(payload).notifyovertime(); }
   }
 
-  @property final StatusCode statuscode() const { return payload.statuscode; }
+  @property final StatusCode statuscode() const {
+    if (isRange && payload.type == PayloadType.File) return StatusCode.PartialContent;
+    return payload.statuscode;
+  }
   @property final bool keepalive() const { return( toLower(connection) == "keep-alive"); }
-  @property final long length() { return header.length + payload.length; }
-  @property final const(char)[] bytes(in ptrdiff_t maxsize = 1024) {                       // Stream of bytes (header + stream of bytes)
+  @property final long length() {
+    if (isRange) return header.length + (rangeEnd - rangeStart + 1);
+    return header.length + payload.length;
+  }
+  @property final const(char)[] bytes(in ptrdiff_t maxsize = 65536) { // Stream of bytes (header + stream of bytes)
     ptrdiff_t hsize = header.length;
     if(index <= hsize) {  // We haven't completed the header yet
       ptrdiff_t remaining = maxsize - hsize;
       return(header[index .. hsize] ~ payload.bytes(0, remaining > 0 ? remaining : 0));
     }
-    return(payload.bytes(index-hsize));                                                    // Header completed, just stream bytes from the payload
+    return(payload.bytes(index-hsize, maxsize, isRange, rangeStart, rangeEnd)); // Header completed, just stream bytes from the payload
   }
 
   @property final bool ready(bool r = false){ if(r){ routed = r; } return(routed && payload.ready()); }
@@ -213,9 +222,9 @@ void serveRangeFile(ref Response response, in Request request, FilePayload reqFi
   } else {
     response.customheader("Content-Range", format("bytes %d-%d/%d", start, end, total));
     response.customheader("Accept-Ranges", "bytes");
-    reqFile.rangeStart = start;
-    reqFile.rangeEnd = end;
-    reqFile.isRange = true;
+    response.rangeStart = start;
+    response.rangeEnd = end;
+    response.isRange = true;
     response.payload = reqFile;
   }
   response.ready = true;

--- a/danode/response.d
+++ b/danode/response.d
@@ -201,7 +201,7 @@ void serveStaticFile(ref Response response, in Request request, FileSystem fs) {
 
   if (request.hasRange) { response.serveRangeFile(request, reqFile); return; }
 
-  response.customheader("Accept-Ranges", "bytes");
+  if (!reqFile.deflate) response.customheader("Accept-Ranges", "bytes");
   if (request.ifModified >= response.payload.mtime()) {                                        // Non modified static content
     trace("static file has not changed, sending notmodified");
     response.notmodified(request, response.payload.mimetype);

--- a/danode/response.d
+++ b/danode/response.d
@@ -200,9 +200,9 @@ void serveStaticFile(ref Response response, in Request request, FileSystem fs) {
   }
   response.payload = reqFile;
 
-  if (request.hasRange) { response.serveRangeFile(request, reqFile); return; }
+  //if (request.hasRange) { response.serveRangeFile(request, reqFile); return; }
 
-  if (!reqFile.deflate) response.customheader("Accept-Ranges", "bytes");
+  //if (!reqFile.deflate) response.customheader("Accept-Ranges", "bytes");
   if (request.ifModified >= response.payload.mtime()) {                                        // Non modified static content
     trace("static file has not changed, sending notmodified");
     response.notmodified(request, response.payload.mimetype);

--- a/danode/response.d
+++ b/danode/response.d
@@ -33,9 +33,9 @@ struct Response {
   bool              cgiheader = false;
   Appender!(char[]) hdr;
   ptrdiff_t         index = 0;
-  bool              isRange    = false;
+/*  bool              isRange    = false;
   long              rangeStart = 0;
-  long              rangeEnd   = -1;
+  long              rangeEnd   = -1;*/
 
   final void customheader(string key, string value) nothrow { headers[key] = value; }
 
@@ -90,8 +90,7 @@ struct Response {
     }
     hdr.put(format("Date: %s\r\n", htmltime()));
     if (payload.type != PayloadType.Script && payload.length >= 0) { // If we have any payload
-      long contentLength = isRange ? (rangeEnd - rangeStart + 1) : payload.length;
-      hdr.put(format("Content-Length: %d\r\n", contentLength));
+      hdr.put(format("Content-Length: %d\r\n", payload.length));
       hdr.put(format("Last-Modified: %s\r\n", htmltime(payload.mtime))); // It could be modified long ago, lets inform the client
       if (maxage > 0) { // Perhaps we can have the client cache it (when very old)
         hdr.put(format("Cache-Control: max-age=%d, public\r\n", maxage));
@@ -108,22 +107,16 @@ struct Response {
     if (payload && payload.type == PayloadType.Script) { to!CGI(payload).notifyovertime(); }
   }
 
-  @property final StatusCode statuscode() const {
-    if (isRange && payload.type == PayloadType.File) return StatusCode.PartialContent;
-    return payload.statuscode;
-  }
+  @property final StatusCode statuscode() const { return payload.statuscode; }
   @property final bool keepalive() const { return( toLower(connection) == "keep-alive"); }
-  @property final long length() {
-    if (isRange) return header.length + (rangeEnd - rangeStart + 1);
-    return header.length + payload.length;
-  }
+  @property final long length() { return header.length + payload.length; }
   @property final const(char)[] bytes(in ptrdiff_t maxsize = 65536) { // Stream of bytes (header + stream of bytes)
     ptrdiff_t hsize = header.length;
     if(index <= hsize) {  // We haven't completed the header yet
       ptrdiff_t remaining = maxsize - hsize;
-      return(header[index .. hsize] ~ payload.bytes(0, remaining > 0 ? remaining : 0, isRange, rangeStart, rangeEnd));
+      return(header[index .. hsize] ~ payload.bytes(0, remaining > 0 ? remaining : 0));
     }
-    return(payload.bytes(index-hsize, maxsize, isRange, rangeStart, rangeEnd)); // Header completed, just stream bytes from the payload
+    return(payload.bytes(index-hsize, maxsize)); // Header completed, just stream bytes from the payload
   }
 
   @property final bool ready(bool r = false){ if(r){ routed = r; } return(routed && payload.ready()); }
@@ -223,9 +216,9 @@ void serveRangeFile(ref Response response, in Request request, FilePayload reqFi
   } else {
     response.customheader("Content-Range", format("bytes %d-%d/%d", start, end, total));
     response.customheader("Accept-Ranges", "bytes");
-    response.rangeStart = start;
-    response.rangeEnd = end;
-    response.isRange = true;
+    //response.rangeStart = start;
+   // response.rangeEnd = end;
+   // response.isRange = true;
     response.payload = reqFile;
   }
   response.ready = true;

--- a/danode/response.d
+++ b/danode/response.d
@@ -84,13 +84,14 @@ struct Response {
       connection = "Close";
     }
     // Construct the header for all other requests (and scripts that failed to provide a valid one
-    hdr.put(format("%s %d %s\r\n", protocol, payload.statuscode, payload.statuscode.reason));
+    hdr.put(format("%s %d %s\r\n", protocol, statuscode, statuscode.reason));
     foreach (key, value; headers) { 
       hdr.put(format("%s: %s\r\n", key, value));
     }
     hdr.put(format("Date: %s\r\n", htmltime()));
     if (payload.type != PayloadType.Script && payload.length >= 0) { // If we have any payload
-      hdr.put(format("Content-Length: %d\r\n", payload.length)); // We can send the expected size
+      long contentLength = isRange ? (rangeEnd - rangeStart + 1) : payload.length;
+      hdr.put(format("Content-Length: %d\r\n", contentLength));
       hdr.put(format("Last-Modified: %s\r\n", htmltime(payload.mtime))); // It could be modified long ago, lets inform the client
       if (maxage > 0) { // Perhaps we can have the client cache it (when very old)
         hdr.put(format("Cache-Control: max-age=%d, public\r\n", maxage));

--- a/danode/response.d
+++ b/danode/response.d
@@ -121,7 +121,7 @@ struct Response {
     ptrdiff_t hsize = header.length;
     if(index <= hsize) {  // We haven't completed the header yet
       ptrdiff_t remaining = maxsize - hsize;
-      return(header[index .. hsize] ~ payload.bytes(0, remaining > 0 ? remaining : 0));
+      return(header[index .. hsize] ~ payload.bytes(0, remaining > 0 ? remaining : 0, isRange, rangeStart, rangeEnd));
     }
     return(payload.bytes(index-hsize, maxsize, isRange, rangeStart, rangeEnd)); // Header completed, just stream bytes from the payload
   }

--- a/danode/response.d
+++ b/danode/response.d
@@ -118,7 +118,7 @@ struct Response {
     return header.length + payload.length;
   }
   // Stream of bytes (header + stream of bytes)
-  @property final const(char)[] bytes(in ptrdiff_t maxsize = 65536) {
+  @property final const(char)[] bytes(in ptrdiff_t maxsize = 4096) {
     ptrdiff_t hsize = header.length;
     if(index <= hsize) {  // We haven't completed the header yet
       ptrdiff_t remaining = maxsize - hsize;


### PR DESCRIPTION
## Fix: Large file downloads and range request support
 
### Root causes
 
1. `Accept-Ranges: bytes` advertised unconditionally, causing browsers to send Range requests that mutated the cached `FilePayload` object — corrupting all subsequent full downloads of the same file
2. `Thread.yield()` caused CPU spinning, starving the TCP send buffer
3. `send()` was inside the `receive > 0` block — large files never completed because the client stops sending data after the initial request
4. SSL `SSL_write` was called with a new buffer on retry — OpenSSL requires retrying with the exact same buffer on `SSL_ERROR_WANT_WRITE`
 
### Fixes
 
- **Range state moved to `Response`** — `FilePayload` is now read-only after caching; `isRange`, `rangeStart`, `rangeEnd` live on `Response` and are passed through `bytes()` as parameters
- **`Thread.yield()` → `Thread.sleep(2ms)`** — prevents spinning and gives the TCP stack time to drain between sends
- **`send()` moved outside `receive > 0` block** — large files keep sending even when no new data arrives from the client
- **`select(0ms)` in `http.d`** — non-blocking writability check before each send; returns immediately if TCP buffer is full
- **`pending` buffer in `https.d`** — buffers the outgoing slice and retries with the exact same data on `SSL_ERROR_WANT_WRITE`, satisfying OpenSSL's retry requirement
