### PR TITLE
ACME auto-renewal, OpenSSL 3.x, TLS hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ www/rotationz.nl
 www/rotationz.test
 www/grassland.test
 www/localhost/ddoc
+bin/
 server
 *.exe
 *.pdb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/openssl"]
+	path = deps/openssl
+	url = https://github.com/openssl/openssl

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-DaNode - A secure and small footprint web server for D 
+DaNode - A secure and small footprint web server for D
 ------------------------------------------------------
 master: [![D](https://github.com/DannyArends/DaNode/actions/workflows/d.yml/badge.svg?branch=master)](https://github.com/DannyArends/DaNode/actions/workflows/d.yml)
 licence: [![license](https://img.shields.io/github/license/DannyArends/DaNode.svg?style=flat)](https://github.com/DannyArends/DaNode/blob/master/LICENSE.txt)

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -1,0 +1,285 @@
+module danode.acme;
+
+version(SSL) {
+  import danode.imports;
+  import danode.includes;
+  import danode.log : info, warning, error;
+  import danode.functions : writeinfile;
+
+  immutable string ACME_DIR_PROD    = "https://acme-v02.api.letsencrypt.org/directory";
+  immutable string ACME_DIR_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
+
+  __gshared string[string] acmeChallenges; // Shared challenge store: token -> keyAuthorization
+
+  // POST a JWS request to an ACME URL and return parsed JSON response
+  JSONValue acmePost(EVP_PKEY* pkey, JSONValue dir, string url, string kid, string payload,
+                     string* location = null) {
+    string nonce    = acmeNonce(dir);
+    string postData = buildJWS(pkey, nonce, url, kid, payload);
+    char[] response;
+    auto http = HTTP(url);
+    http.method = HTTP.Method.post;
+    http.addRequestHeader("Content-Type", "application/jose+json");
+    http.postData = postData;
+    http.onReceive = (ubyte[] data) { response ~= cast(char[]) data; return data.length; };
+    if (location !is null) {
+      http.onReceiveHeader = (in char[] key, in char[] value) {
+        if (icmp(key, "location") == 0) *location = value.idup;
+      };
+    }
+    http.perform();
+    return parseJSON(response);
+  }
+
+  // Full ACME renewal flow
+  bool renewCert(string domain, string email, string csrPath, string chainPath, string accountKey, bool staging) {
+    info("ACME: starting renewal for %s", domain);
+
+    EVP_PKEY* pkey = loadAccountKey(accountKey);
+    if (pkey is null) return false;
+
+    JSONValue dir = acmeDirectory(staging);
+    string kid = acmeAccountURL(dir, pkey, email);
+    if (kid.length == 0) { error("ACME: failed to get account URL"); return false; }
+    info("ACME: account URL: %s", kid);
+
+    string orderURL;
+    JSONValue order = newOrder(dir, pkey, kid, domain, orderURL);
+    JSONValue challenge = getHTTP01Challenge(order, dir, pkey, kid);
+    if (challenge.type == JSONType.null_) return false;
+
+    string token = prepareChallenge(challenge, pkey);
+    triggerChallenge(challenge, dir, pkey, kid);
+
+    if (!pollAuthorization(order, dir, pkey, kid)) { acmeChallenges.remove(token); return false; }
+    acmeChallenges.remove(token);
+
+    JSONValue finalized = finalizeOrder(order, dir, pkey, kid, csrPath);
+    info("ACME: order status: %s", finalized["status"].str);
+
+    foreach (i; 0 .. 10) { // Poll until certificate is ready
+      if (finalized["status"].str == "valid") break;
+      Thread.sleep(dur!"seconds"(5));
+      finalized = acmePost(pkey, dir, orderURL, kid, "");
+    }
+    return downloadCert(finalized, dir, pkey, kid, chainPath);
+  }
+
+    // Check cert expiry and renew if < 30 days remaining
+  void checkAndRenew(string certDir = ".ssl/", string accountKey = ".ssl/account.key", bool staging = true) {
+    info("ACME: checkAndRenew called on '%s' with key '%s'", certDir, accountKey);
+    foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
+      if (!d.name.endsWith(".crt")) continue;
+      string domain = baseName(d.name, ".crt");
+
+      BIO* bio = BIO_new_file(toStringz(d.name), "r");
+      X509* cert = PEM_read_bio_X509(bio, null, null, null);
+      BIO_free(bio);
+      if (cert is null) continue;
+
+      ASN1_TIME* notAfter = X509_getm_notAfter(cert);
+      int days;
+      int secs;
+      ASN1_TIME_diff(&days, &secs, null, notAfter);
+      X509_free(cert);
+
+      info("ACME: cert %s expires in %d days", domain, days);
+      if (days < 30) { info("ACME: renewing cert for %s", domain);
+        renewCert(domain, "Danny.Arends@gmail.com", certDir ~ domain ~ ".csr", certDir ~ domain ~ ".chain", accountKey, staging);
+      }
+    }
+  }
+
+  // Base64url encode without padding
+  string b64url(const(ubyte)[] data) { return Base64URL.encode(data).replace("=", ""); }
+
+  // Fetch the ACME directory and return as JSONValue
+  JSONValue acmeDirectory(bool staging) { return parseJSON(get(staging ? ACME_DIR_STAGING : ACME_DIR_PROD)); }
+
+  // Compute and store key authorization for a challenge
+  string prepareChallenge(JSONValue challenge, EVP_PKEY* pkey) {
+    string token = challenge["token"].str;
+    string keyAuth = token ~ "." ~ jwkThumbprint(pkey);
+    acmeChallenges[token] = keyAuth;
+    info("ACME: challenge token: %s", token);
+    return token;
+  }
+
+  // Finalize order by submitting CSR (DER encoded, base64url)
+  JSONValue finalizeOrder(JSONValue order, JSONValue dir, EVP_PKEY* pkey, string kid, string csrPath) {
+    // Load CSR from file
+    BIO* bio = BIO_new_file(toStringz(csrPath), "r");
+    X509_REQ* req = PEM_read_bio_X509_REQ(bio, null, null, null);
+    BIO_free(bio);
+
+    // Convert CSR to DER
+    ubyte* der = null;
+    int derlen = i2d_X509_REQ(req, &der);
+    ubyte[] csrDER = der[0 .. derlen].dup;
+    CRYPTO_free(der, "acme.d", 0);
+    X509_REQ_free(req);
+
+    return acmePost(pkey, dir, order["finalize"].str, kid, `{"csr":"` ~ b64url(csrDER) ~ `"}`);
+  }
+
+  // Download and save certificate chain
+  bool downloadCert(JSONValue order, JSONValue dir, EVP_PKEY* pkey, string kid, string certPath) {
+    string certURL = order["certificate"].str;
+    string nonce = acmeNonce(dir);
+    string postData = buildJWS(pkey, nonce, certURL, kid, "");  // POST-as-GET
+
+    char[] response;
+    auto http = HTTP(certURL);
+    http.method = HTTP.Method.post;
+    http.addRequestHeader("Content-Type", "application/jose+json");
+    http.postData = postData;
+    http.onReceive = (ubyte[] data) { response ~= cast(char[]) data; return data.length; };
+    http.perform();
+
+    writeinfile(certPath, cast(string) response);
+    info("ACME: certificate saved to %s", certPath);
+    return true;
+  }
+
+  // Notify LE to validate the HTTP-01 challenge
+  void triggerChallenge(JSONValue challenge, JSONValue dir, EVP_PKEY* pkey, string kid) {
+    acmePost(pkey, dir, challenge["url"].str, kid, "{}");
+  }
+
+  // Poll authorization URL until valid or invalid
+  bool pollAuthorization(JSONValue order, JSONValue dir, EVP_PKEY* pkey, string kid) {
+    string authURL = order["authorizations"][0].str;
+    foreach (i; 0 .. 10) {
+      Thread.sleep(dur!"seconds"(2));
+      JSONValue auth = acmePost(pkey, dir, authURL, kid, "");
+
+      string status = auth["status"].str;
+      info("ACME: authorization status: %s", status);
+      if (status == "valid")   return true;
+      if (status == "invalid") { error("ACME: authorization failed"); return false; }
+    }
+    error("ACME: authorization timed out");
+    return false;
+  }
+
+  // Place a new order for a domain certificate
+  JSONValue newOrder(JSONValue dir, EVP_PKEY* pkey, string kid, string domain, out string orderURL) {
+    return acmePost(pkey, dir, dir["newOrder"].str, kid, `{"identifiers":[{"type":"dns","value":"` ~ domain ~ `"}]}`, &orderURL);
+  }
+
+  // Fetch challenge URL and token for HTTP-01 from an order
+  JSONValue getHTTP01Challenge(JSONValue order, JSONValue dir, EVP_PKEY* pkey, string kid) {
+    JSONValue auth = acmePost(pkey, dir, order["authorizations"][0].str, kid, "");
+
+    foreach (challenge; auth["challenges"].array) { if (challenge["type"].str == "http-01") return challenge; }
+    error("ACME: no HTTP-01 challenge found");
+    return JSONValue.init;
+  }
+
+ // Compute SHA256 thumbprint of the public JWK
+  string jwkThumbprint(EVP_PKEY* pkey) {
+    // JWK thumbprint requires canonical JSON: sorted keys, no whitespace
+    BIGNUM* bn_n = BN_new();
+    BIGNUM* bn_e = BN_new();
+    EVP_PKEY_get_bn_param(pkey, "n", &bn_n);
+    EVP_PKEY_get_bn_param(pkey, "e", &bn_e);
+    int nlen = BN_num_bytes(bn_n);
+    int elen = BN_num_bytes(bn_e);
+    ubyte[] nbuf = new ubyte[](nlen);
+    ubyte[] ebuf = new ubyte[](elen);
+    BN_bn2bin(bn_n, nbuf.ptr);
+    BN_bn2bin(bn_e, ebuf.ptr);
+    BN_free(bn_n);
+    BN_free(bn_e);
+
+    // RFC 7638 canonical form - keys must be sorted alphabetically
+    string canonical = `{"e":"` ~ b64url(ebuf) ~ `","kty":"RSA","n":"` ~ b64url(nbuf) ~ `"}`;
+
+    ubyte[32] digest;
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    scope(exit) EVP_MD_CTX_free(ctx);
+    EVP_DigestInit_ex(ctx, EVP_sha256(), null);
+    EVP_DigestUpdate(ctx, canonical.ptr, canonical.length);
+    uint dlen = 32;
+    EVP_DigestFinal_ex(ctx, digest.ptr, &dlen);
+    return b64url(digest[0 .. dlen]);
+  }
+
+  // Fetch a fresh nonce from ACME
+  string acmeNonce(JSONValue dir) {
+    auto http = HTTP(dir["newNonce"].str);
+    http.method = HTTP.Method.head;
+    string nonce;
+    http.onReceiveHeader = (in char[] key, in char[] value) { if (icmp(key, "replay-nonce") == 0) nonce = value.idup; };
+    http.perform();
+    return nonce;
+  }
+
+  // Get account URL using existing account key (onlyReturnExisting)
+  string acmeAccountURL(JSONValue dir, EVP_PKEY* pkey, string email) {
+    string kid;
+    acmePost(pkey, dir, dir["newAccount"].str, "", `{"termsOfServiceAgreed":true,"onlyReturnExisting":true,"contact":["mailto:` ~ email ~ `"]}`, &kid);
+    return kid;
+  }
+
+  // Extract public key as JWK JSON (for newAccount header)
+  string jwkPublic(EVP_PKEY* pkey) {
+    import std.json : JSONValue, toJSON;
+    BIGNUM* bn_n = BN_new();
+    BIGNUM* bn_e = BN_new();
+    EVP_PKEY_get_bn_param(pkey, "n", &bn_n);
+    EVP_PKEY_get_bn_param(pkey, "e", &bn_e);
+
+    int nlen = BN_num_bytes(bn_n);
+    int elen = BN_num_bytes(bn_e);
+    ubyte[] nbuf = new ubyte[](nlen);
+    ubyte[] ebuf = new ubyte[](elen);
+    BN_bn2bin(bn_n, nbuf.ptr);
+    BN_bn2bin(bn_e, ebuf.ptr);
+    BN_free(bn_n);
+    BN_free(bn_e);
+
+    JSONValue jwk = ["kty": JSONValue("RSA"), "n": JSONValue(b64url(nbuf)), "e": JSONValue(b64url(ebuf))];
+    return toJSON(jwk);
+  }
+
+  // Sign data with RS256 using the account key
+  ubyte[] signRS256(EVP_PKEY* pkey, const(ubyte)[] data) {
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    if (ctx is null) { error("ACME: EVP_MD_CTX_new failed"); return null; }
+    scope(exit) EVP_MD_CTX_free(ctx);
+
+    if (EVP_DigestSignInit(ctx, null, EVP_sha256(), null, pkey) <= 0) { error("ACME: EVP_DigestSignInit failed"); return null; }
+    if (EVP_DigestSignUpdate(ctx, data.ptr, data.length) <= 0) { error("ACME: EVP_DigestSignUpdate failed"); return null; }
+    size_t siglen;
+    if (EVP_DigestSignFinal(ctx, null, &siglen) <= 0) { error("ACME: EVP_DigestSignFinal (len) failed"); return null; }
+    ubyte[] sig = new ubyte[](siglen);
+    if (EVP_DigestSignFinal(ctx, sig.ptr, &siglen) <= 0) { error("ACME: EVP_DigestSignFinal failed"); return null; }
+    return sig[0 .. siglen];
+  }
+
+  // Build a JWS signed request
+  string buildJWS(EVP_PKEY* pkey, string nonce, string url, string kid, string payload) {
+    JSONValue hdr;
+    if (kid.length) {
+      hdr = ["alg": JSONValue("RS256"), "nonce": JSONValue(nonce), "url": JSONValue(url), "kid": JSONValue(kid)];
+    } else {
+      hdr = ["alg": JSONValue("RS256"), "nonce": JSONValue(nonce), "url": JSONValue(url), "jwk": JSONValue(parseJSON(jwkPublic(pkey)))];
+    }
+    string protected_ = b64url(cast(ubyte[]) toJSON(hdr));
+    string payload64 = payload.length ? b64url(cast(ubyte[]) payload) : "";
+    string sigInput = protected_ ~ "." ~ payload64;
+    ubyte[] sig = signRS256(pkey, cast(ubyte[]) sigInput);
+    return `{"protected":"` ~ protected_ ~ `","payload":"` ~ payload64 ~ `","signature":"` ~ b64url(sig) ~ `"}`;
+  }
+
+  EVP_PKEY* loadAccountKey(string path = ".ssl/account.key") {
+    BIO* bio = BIO_new_file(toStringz(path), "r");
+    if (bio is null) { error("ACME: cannot open account key: %s", path); return null; }
+    EVP_PKEY* pkey = PEM_read_bio_PrivateKey(bio, null, null, null);
+    BIO_free(bio);
+    if (pkey is null) { error("ACME: failed to parse account key"); return null; }
+    info("ACME: account key loaded from %s", path);
+    return pkey;
+  }
+}

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -81,14 +81,8 @@ version(SSL) {
       string domain = baseName(d.name, ".csr");
       string chainPath = certDir ~ domain ~ ".chain";
 
-      auto _certDir = certDir; auto _keyFile = keyFile; auto _domain = domain;
-      auto _csr = d.name; auto _chain = chainPath; auto _key = accountKey; auto _staging = staging;
       if (!exists(chainPath)) { info("ACME: no chain found for %s, bootstrapping", domain);
-        new Thread({
-          if (renewCert(_domain, "Danny.Arends@gmail.com", _csr, _chain, _key, _staging)) {
-            reloadSSL(_certDir, _keyFile);
-          }
-        }).start();
+        if (renewCert(_domain, "Danny.Arends@gmail.com", _csr, _chain, _key, _staging)) { reloadSSL(_certDir, _keyFile); }
         continue;
       }
 
@@ -104,11 +98,7 @@ version(SSL) {
 
       info("ACME: chain %s expires in %d days", domain, days);
       if (days < 30) { info("ACME: renewing chain for %s", domain);
-        new Thread({
-          if (renewCert(_domain, "Danny.Arends@gmail.com", _csr, _chain, _key, _staging)) {
-            reloadSSL(_certDir, _keyFile);
-          }
-        }).start();
+        if (renewCert(_domain, "Danny.Arends@gmail.com", _csr, _chain, _key, _staging)) { reloadSSL(_certDir, _keyFile); }
       }
     }
   }

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -53,14 +53,19 @@ version(SSL) {
     string orderURL;
     JSONValue order = newOrder(dir, pkey, kid, domain, orderURL);
     info("ACME: order: %s, orderURL: %s", order.toString(), orderURL);
-    JSONValue challenge = getHTTP01Challenge(order, dir, pkey, kid);
-    if (challenge.type == JSONType.null_) return false;
+    string[] tokens;
+    foreach (authURL; order["authorizations"].array) {
+      JSONValue challenge = getHTTP01Challenge(authURL.str, dir, pkey, kid);
+      if (challenge.type == JSONType.null_) return false;
+      tokens ~= prepareChallenge(challenge, pkey);
+      triggerChallenge(challenge, dir, pkey, kid);
+    }
 
-    string token = prepareChallenge(challenge, pkey);
-    triggerChallenge(challenge, dir, pkey, kid);
-
-    if (!pollAuthorization(order, dir, pkey, kid)) { synchronized(getAcmeMutex()) { acmeChallenges.remove(token); } return false; }
-    synchronized(getAcmeMutex()) { acmeChallenges.remove(token); }
+    if (!pollAllAuthorizations(order, dir, pkey, kid)) {
+      foreach (t; tokens) synchronized(getAcmeMutex()) { acmeChallenges.remove(t); }
+      return false;
+    }
+    foreach (t; tokens) synchronized(getAcmeMutex()) { acmeChallenges.remove(t); }
 
     JSONValue finalized = finalizeOrder(order, dir, pkey, kid, csrPath);
     info("ACME: order status: %s, finalized: %s", finalized["status"].str, finalized.toString());
@@ -161,16 +166,18 @@ version(SSL) {
   }
 
   // Poll authorization URL until valid or invalid
-  bool pollAuthorization(JSONValue order, JSONValue dir, EVP_PKEY* pkey, string kid) {
-    string authURL = order["authorizations"][0].str;
+  bool pollAllAuthorizations(JSONValue order, JSONValue dir, EVP_PKEY* pkey, string kid) {
     foreach (i; 0 .. 10) {
       Thread.sleep(dur!"seconds"(2));
-      JSONValue auth = acmePost(pkey, dir, authURL, kid, "");
-
-      string status = auth["status"].str;
-      info("ACME: authorization status: %s", status);
-      if (status == "valid")   return true;
-      if (status == "invalid") { error("ACME: authorization failed"); return false; }
+      bool allValid = true;
+      foreach (authURL; order["authorizations"].array) {
+        JSONValue auth = acmePost(pkey, dir, authURL.str, kid, "");
+        string status = auth["status"].str;
+        info("ACME: authorization status for %s: %s", authURL.str, status);
+        if (status == "invalid") { error("ACME: authorization failed"); return false; }
+        if (status != "valid") allValid = false;
+      }
+      if (allValid) return true;
     }
     error("ACME: authorization timed out");
     return false;
@@ -182,9 +189,8 @@ version(SSL) {
   }
 
   // Fetch challenge URL and token for HTTP-01 from an order
-  JSONValue getHTTP01Challenge(JSONValue order, JSONValue dir, EVP_PKEY* pkey, string kid) {
-    JSONValue auth = acmePost(pkey, dir, order["authorizations"][0].str, kid, "");
-
+  JSONValue getHTTP01Challenge(string authURL, JSONValue dir, EVP_PKEY* pkey, string kid) {
+    JSONValue auth = acmePost(pkey, dir, authURL, kid, "");
     foreach (challenge; auth["challenges"].array) { if (challenge["type"].str == "http-01") return challenge; }
     error("ACME: no HTTP-01 challenge found");
     return JSONValue.init;

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -82,7 +82,7 @@ version(SSL) {
       string chainPath = certDir ~ domain ~ ".chain";
 
       if (!exists(chainPath)) { info("ACME: no chain found for %s, bootstrapping", domain);
-        if (renewCert(_domain, "Danny.Arends@gmail.com", _csr, _chain, _key, _staging)) { reloadSSL(_certDir, _keyFile); }
+        if (renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)) { reloadSSL(certDir, keyFile); }
         continue;
       }
 
@@ -98,7 +98,7 @@ version(SSL) {
 
       info("ACME: chain %s expires in %d days", domain, days);
       if (days < 30) { info("ACME: renewing chain for %s", domain);
-        if (renewCert(_domain, "Danny.Arends@gmail.com", _csr, _chain, _key, _staging)) { reloadSSL(_certDir, _keyFile); }
+        if (renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)) { reloadSSL(certDir, keyFile); }
       }
     }
   }

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -178,7 +178,7 @@ version(SSL) {
 
   // Place a new order for a domain certificate
   JSONValue newOrder(JSONValue dir, EVP_PKEY* pkey, string kid, string domain, out string orderURL) {
-    return acmePost(pkey, dir, dir["newOrder"].str, kid, `{"identifiers":[{"type":"dns","value":"` ~ domain ~ `"}]}`, &orderURL);
+    return acmePost(pkey, dir, dir["newOrder"].str, kid, `{"identifiers":[{"type":"dns","value":"` ~ domain ~ `"},{"type":"dns","value":"www.` ~ domain ~ `"}]}`, &orderURL);
   }
 
   // Fetch challenge URL and token for HTTP-01 from an order

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -11,6 +11,11 @@ version(SSL) {
   immutable string ACME_DIR_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
 
   __gshared string[string] acmeChallenges; // Shared challenge store: token -> keyAuthorization
+  __gshared Mutex acmeMutex;
+  Mutex getAcmeMutex() {
+    if (acmeMutex is null) acmeMutex = new Mutex();
+    return acmeMutex;
+  }
 
   // POST a JWS request to an ACME URL and return parsed JSON response
   JSONValue acmePost(EVP_PKEY* pkey, JSONValue dir, string url, string kid, string payload,
@@ -54,8 +59,8 @@ version(SSL) {
     string token = prepareChallenge(challenge, pkey);
     triggerChallenge(challenge, dir, pkey, kid);
 
-    if (!pollAuthorization(order, dir, pkey, kid)) { acmeChallenges.remove(token); return false; }
-    acmeChallenges.remove(token);
+    if (!pollAuthorization(order, dir, pkey, kid)) { synchronized(getAcmeMutex()) { acmeChallenges.remove(token); } return false; }
+    synchronized(getAcmeMutex()) { acmeChallenges.remove(token); }
 
     JSONValue finalized = finalizeOrder(order, dir, pkey, kid, csrPath);
     info("ACME: order status: %s, finalized: %s", finalized["status"].str, finalized.toString());
@@ -76,8 +81,14 @@ version(SSL) {
       string domain = baseName(d.name, ".csr");
       string chainPath = certDir ~ domain ~ ".chain";
 
+      auto _certDir = certDir; auto _keyFile = keyFile; auto _domain = domain;
+      auto _csr = d.name; auto _chain = chainPath; auto _key = accountKey; auto _staging = staging;
       if (!exists(chainPath)) { info("ACME: no chain found for %s, bootstrapping", domain);
-        if(renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)){ reloadSSL(certDir, keyFile); }
+        new Thread({
+          if (renewCert(_domain, "Danny.Arends@gmail.com", _csr, _chain, _key, _staging)) {
+            reloadSSL(_certDir, _keyFile);
+          }
+        }).start();
         continue;
       }
 
@@ -93,7 +104,11 @@ version(SSL) {
 
       info("ACME: chain %s expires in %d days", domain, days);
       if (days < 30) { info("ACME: renewing chain for %s", domain);
-        if(renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)){ reloadSSL(certDir, keyFile); }
+        new Thread({
+          if (renewCert(_domain, "Danny.Arends@gmail.com", _csr, _chain, _key, _staging)) {
+            reloadSSL(_certDir, _keyFile);
+          }
+        }).start();
       }
     }
   }
@@ -108,7 +123,7 @@ version(SSL) {
   string prepareChallenge(JSONValue challenge, EVP_PKEY* pkey) {
     string token = challenge["token"].str;
     string keyAuth = token ~ "." ~ jwkThumbprint(pkey);
-    acmeChallenges[token] = keyAuth;
+    synchronized(getAcmeMutex()) { acmeChallenges[token] = keyAuth; }
     info("ACME: challenge token: %s", token);
     return token;
   }

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -4,6 +4,7 @@ version(SSL) {
   import danode.imports;
   import danode.includes;
   import danode.log : info, warning, error;
+  import danode.ssl : reloadSSL;
   import danode.functions : writeinfile;
 
   immutable string ACME_DIR_PROD    = "https://acme-v02.api.letsencrypt.org/directory";
@@ -68,7 +69,7 @@ version(SSL) {
   }
 
     // Check cert expiry and renew if < 30 days remaining
-  void checkAndRenew(string certDir = ".ssl/", string accountKey = ".ssl/account.key", bool staging = true) {
+  void checkAndRenew(string certDir = ".ssl/", string keyFile = ".ssl/server.key", string accountKey = ".ssl/account.key", bool staging = true) {
     info("ACME: checkAndRenew called on '%s' with key '%s'", certDir, accountKey);
     foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
       if (!d.name.endsWith(".csr")) continue;
@@ -92,7 +93,9 @@ version(SSL) {
 
       info("ACME: chain %s expires in %d days", domain, days);
       if (days < 30) { info("ACME: renewing chain for %s", domain);
-        renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging);
+        if(renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)){
+          reloadSSL(certDir, keyFile);
+        }
       }
     }
   }
@@ -117,6 +120,7 @@ version(SSL) {
     // Load CSR from file
     BIO* bio = BIO_new_file(toStringz(csrPath), "r");
     X509_REQ* req = PEM_read_bio_X509_REQ(bio, null, null, null);
+    if (req is null) { error("ACME: failed to load CSR from %s", csrPath); return JSONValue.init; }
     BIO_free(bio);
 
     // Convert CSR to DER

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -77,7 +77,7 @@ version(SSL) {
       string chainPath = certDir ~ domain ~ ".chain";
 
       if (!exists(chainPath)) { info("ACME: no chain found for %s, bootstrapping", domain);
-        renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging);
+        if(renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)){ reloadSSL(certDir, keyFile); }
         continue;
       }
 
@@ -93,9 +93,7 @@ version(SSL) {
 
       info("ACME: chain %s expires in %d days", domain, days);
       if (days < 30) { info("ACME: renewing chain for %s", domain);
-        if(renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)){
-          reloadSSL(certDir, keyFile);
-        }
+        if(renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)){ reloadSSL(certDir, keyFile); }
       }
     }
   }

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -28,6 +28,7 @@ version(SSL) {
       };
     }
     http.perform();
+    info("ACME: POST %s -> %s", url, cast(string) response);
     return parseJSON(response);
   }
 
@@ -45,6 +46,7 @@ version(SSL) {
 
     string orderURL;
     JSONValue order = newOrder(dir, pkey, kid, domain, orderURL);
+    info("ACME: order: %s, orderURL: %s", order.toString(), orderURL);
     JSONValue challenge = getHTTP01Challenge(order, dir, pkey, kid);
     if (challenge.type == JSONType.null_) return false;
 
@@ -55,7 +57,7 @@ version(SSL) {
     acmeChallenges.remove(token);
 
     JSONValue finalized = finalizeOrder(order, dir, pkey, kid, csrPath);
-    info("ACME: order status: %s", finalized["status"].str);
+    info("ACME: order status: %s, finalized: %s", finalized["status"].str, finalized.toString());
 
     foreach (i; 0 .. 10) { // Poll until certificate is ready
       if (finalized["status"].str == "valid") break;
@@ -219,6 +221,7 @@ version(SSL) {
   string acmeAccountURL(JSONValue dir, EVP_PKEY* pkey, string email) {
     string kid;
     acmePost(pkey, dir, dir["newAccount"].str, "", `{"termsOfServiceAgreed":true,"onlyReturnExisting":true,"contact":["mailto:` ~ email ~ `"]}`, &kid);
+    info("ACME: kid: %s", kid);
     return kid;
   }
 

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -79,7 +79,7 @@ version(SSL) {
   }
 
     // Check cert expiry and renew if < 30 days remaining
-  void checkAndRenew(string certDir = ".ssl/", string keyFile = ".ssl/server.key", string accountKey = ".ssl/account.key", bool staging = true) {
+  void checkAndRenew(string certDir = ".ssl/", string keyFile = ".ssl/server.key", string accountKey = ".ssl/account.key", bool staging = false) {
     info("ACME: checkAndRenew called on '%s' with key '%s'", certDir, accountKey);
     foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
       if (!d.name.endsWith(".csr")) continue;

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -71,23 +71,28 @@ version(SSL) {
   void checkAndRenew(string certDir = ".ssl/", string accountKey = ".ssl/account.key", bool staging = true) {
     info("ACME: checkAndRenew called on '%s' with key '%s'", certDir, accountKey);
     foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
-      if (!d.name.endsWith(".crt")) continue;
-      string domain = baseName(d.name, ".crt");
+      if (!d.name.endsWith(".csr")) continue;
+      string domain = baseName(d.name, ".csr");
+      string chainPath = certDir ~ domain ~ ".chain";
 
-      BIO* bio = BIO_new_file(toStringz(d.name), "r");
+      if (!exists(chainPath)) { info("ACME: no chain found for %s, bootstrapping", domain);
+        renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging);
+        continue;
+      }
+
+      BIO* bio = BIO_new_file(toStringz(chainPath), "r");
       X509* cert = PEM_read_bio_X509(bio, null, null, null);
       BIO_free(bio);
       if (cert is null) continue;
 
       ASN1_TIME* notAfter = X509_getm_notAfter(cert);
-      int days;
-      int secs;
+      int days, secs;
       ASN1_TIME_diff(&days, &secs, null, notAfter);
       X509_free(cert);
 
-      info("ACME: cert %s expires in %d days", domain, days);
-      if (days < 30) { info("ACME: renewing cert for %s", domain);
-        renewCert(domain, "Danny.Arends@gmail.com", certDir ~ domain ~ ".csr", certDir ~ domain ~ ".chain", accountKey, staging);
+      info("ACME: chain %s expires in %d days", domain, days);
+      if (days < 30) { info("ACME: renewing chain for %s", domain);
+        renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging);
       }
     }
   }

--- a/danode/client.d
+++ b/danode/client.d
@@ -32,7 +32,7 @@ class Client : Thread, ClientInterface {
    final void run() {
       trace("new connection established %s:%d", ip(), port() );
       try {
-        if (driver.openConnection() == false) { warning("new connection aborted: unable to open connection"); stop(); }
+        if (driver.openConnection() == false) { custom(2, "WARN", "new connection aborted: unable to open connection"); stop(); }
         Request request;
         Response response;
         scope (exit) {

--- a/danode/files.d
+++ b/danode/files.d
@@ -75,14 +75,8 @@ class FilePayload : Payload {
     final bool needsupdate() {
       if (!isStaticFile()) return false; // CGI files are never buffered, since they are executed
       if (fileSize() > 0 && fileSize() < buffermaxsize) { //
-        if (!buffered) {
-          info("need to buffer file record: %s", path);
-          return true;
-        }
-        if (mtime > btime) {
-          info("re-buffer stale file record: %s", path);
-          return true;
-        }
+        if (!buffered) { trace("need to buffer file record: %s", path); return true; }
+        if (mtime > btime) { trace("re-buffer stale file record: %s", path); return true; }
       }else{
         info("file %s does not fit into the buffer (%d)", path, buffermaxsize);
       }

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -54,7 +54,7 @@ class FileSystem {
         if (f.isFile()) {
           string shortname = replace(f.name[dname.length .. $], "\\", "/");
           if (shortname.endsWith(".in") || shortname.endsWith(".up")) continue;
-          custom(1, "SCAN", "file: %s -> %s", f.name, shortname);
+          custom(2, "SCAN", "file: %s -> %s", f.name, shortname);
           if (!domain.files.has(shortname)) {
             domain.files[shortname] = new FilePayload(f.name, maxsize);
             domain.entries++;
@@ -91,7 +91,7 @@ class FileSystem {
         if (domains[localroot].files[path].needsupdate) domains[localroot].files[path].buffer();
         return(domains[localroot].files[path]);
       }
-      custom(1, "SCAN", "should not be here not in index, but exists %s, %s", path, localroot);
+      custom(0, "SCAN", "should not be here not in index, but exists %s, %s", path, localroot);
       return new FilePayload("", maxsize);
     } }
 

--- a/danode/https.d
+++ b/danode/https.d
@@ -1,8 +1,7 @@
 module danode.https;
 
 version(SSL) {
-  import deimos.openssl.ssl;
-  import deimos.openssl.err;
+  import danode.includes;
 
   import danode.imports;
   import danode.functions : Msecs;

--- a/danode/https.d
+++ b/danode/https.d
@@ -100,6 +100,7 @@ version(SSL) {
             if (socket.isAlive()) {
               if (ssl) {
                 SSL_shutdown(ssl);
+                SSL_shutdown(ssl);
               } else {
                 error("No SSL object to close, are certificates available?");
               }

--- a/danode/https.d
+++ b/danode/https.d
@@ -71,7 +71,7 @@ version(SSL) {
 
             bool handshaked = performHandshake();
             if (!handshaked) {
-              error("couldn't handshake SSL connection");
+              custom(2, "ERROR", "couldn't handshake SSL connection");
               return(false);
             }
           } catch (Exception e) {

--- a/danode/imports.d
+++ b/danode/imports.d
@@ -6,6 +6,7 @@ public import core.stdc.stdio : fileno, printf;
 
 // Public imported structures and enums from core
 public import core.atomic;
+public import core.sync.mutex : Mutex;
 public import core.thread;
 
 // Public imported function from std

--- a/danode/imports.d
+++ b/danode/imports.d
@@ -9,14 +9,17 @@ public import core.atomic;
 public import core.thread;
 
 // Public imported function from std
-public import std.algorithm : mean, canFind, min, max;
+public import std.algorithm;
 public import std.array;
+public import std.base64 : Base64URL;
 public import std.compiler;
 public import std.conv;
 public import std.datetime;
 public import std.file;
 public import std.format;
 public import std.getopt;
+public import std.json;
+public import std.net.curl : HTTP, get;
 public import std.path;
 public import std.process;
 public import std.regex;

--- a/danode/includes.c
+++ b/danode/includes.c
@@ -1,0 +1,2 @@
+#include <openssl/ssl.h>
+#include <openssl/err.h>

--- a/danode/includes.c
+++ b/danode/includes.c
@@ -1,3 +1,6 @@
 #define OPENSSL_NO_DEPRECATED
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/evp.h>

--- a/danode/includes.c
+++ b/danode/includes.c
@@ -1,2 +1,3 @@
+#define OPENSSL_NO_DEPRECATED
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/danode/log.d
+++ b/danode/log.d
@@ -108,7 +108,7 @@ class Log {
       string uri;
       try { uri = decodeComponent(rq.uri); } catch (Exception e) { uri = rq.uri; }
       long bytes = rs.isRange ? (rs.rangeEnd - rs.rangeStart + 1) : rs.payload.length;
-      string s = format("[%d]    %s %s:%s %s%s %s %s", rs.statuscode, htmltime(), cl.ip, cl.port, rq.shorthost, uri, Msecs(rq.starttime), bytes);
+      string s = format("[%d]    %s %s:%s %s%s %s %s", rs.statuscode, htmltime(), cl.ip, cl.port, rq.shorthost, uri.replace("%", "%%"), Msecs(rq.starttime), bytes);
       RequestLogFp.writeln(s);
       custom(-1, "REQ", s);
       RequestLogFp.flush();

--- a/danode/post.d
+++ b/danode/post.d
@@ -151,7 +151,8 @@ final void serverAPI(in FileSystem filesystem, in WebConfig config, in Request r
   content.put(format("S=GATEWAY_INTERFACE=%s\n", "CGI/1.1"));
   content.put(format("S=PHP_SELF=%s\n", request.path));
   content.put(format("S=REQUEST_TIME=%s\n", request.starttime.toUnixTime));
-
+  content.put(format("S=REMOTE_PAGE=%s\n", request.page));
+  content.put(format("S=REQUEST_DIR=%s\n", request.dir));
   // Write the post information we received
   foreach (p; request.postinfo) {
     if(p.type == PostType.Input)  content.put(format("P=%s=%s\n", p.name, p.value));

--- a/danode/post.d
+++ b/danode/post.d
@@ -151,8 +151,10 @@ final void serverAPI(in FileSystem filesystem, in WebConfig config, in Request r
   content.put(format("S=GATEWAY_INTERFACE=%s\n", "CGI/1.1"));
   content.put(format("S=PHP_SELF=%s\n", request.path));
   content.put(format("S=REQUEST_TIME=%s\n", request.starttime.toUnixTime));
-  content.put(format("S=REMOTE_PAGE=%s\n", request.page));
+
+  // This is DaNode specific
   content.put(format("S=REQUEST_DIR=%s\n", request.dir));
+
   // Write the post information we received
   foreach (p; request.postinfo) {
     if(p.type == PostType.Input)  content.put(format("P=%s=%s\n", p.name, p.value));

--- a/danode/request.d
+++ b/danode/request.d
@@ -48,7 +48,6 @@ struct Request {
   RequestMethod method; /// requested HTTP method
   string uri = "/"; /// raw URI from the request line, never modified after parsing
   string url = "/"; /// working path used for routing, may be rewritten by canonical/directory redirects
-  string page; /// original URI for canonical redirects
   string dir;  /// original dir path for directory redirects
   HTTPVersion protocol; /// protocol requested
   string[string] headers; /// Associative array holding the header values

--- a/danode/request.d
+++ b/danode/request.d
@@ -176,7 +176,7 @@ struct Request {
     string[string] env = environment.toAA();
     env["REQUEST_METHOD"] = to!string(method);
     env["QUERY_STRING"] = query.length > 1 ? query[1 .. $] : "";
-    env["REQUEST_URI"] = uripath;
+    env["REQUEST_URI"] = decodeComponent(uripath);
     env["SCRIPT_FILENAME"] = localpath;
     env["SCRIPT_NAME"] = path;
     env["SERVER_PROTOCOL"] = cast(string)protocol;

--- a/danode/request.d
+++ b/danode/request.d
@@ -48,6 +48,8 @@ struct Request {
   RequestMethod method; /// requested HTTP method
   string uri = "/"; /// raw URI from the request line, never modified after parsing
   string url = "/"; /// working path used for routing, may be rewritten by canonical/directory redirects
+  string page; /// original URI for canonical redirects
+  string dir;  /// original dir path for directory redirects
   HTTPVersion protocol; /// protocol requested
   string[string] headers; /// Associative array holding the header values
   SysTime starttime; /// start time of the Request
@@ -189,6 +191,7 @@ struct Request {
 
   // Canonical redirect of the Request for a directory to the index page specified in the WebConfig
   final void redirectdir(in WebConfig config) {
+    this.dir = this.path()[1..$];
     if(config.redirectdir() && config.redirect) { this.url = config.index; }
   }
 

--- a/danode/response.d
+++ b/danode/response.d
@@ -137,7 +137,7 @@ Response create(in Request request, Address address, in StatusCode statuscode = 
 void redirect(ref Response response, in Request request, in string fqdn, bool isSecure = false) {
   trace("redirecting request to %s", fqdn);
   response.payload = new Empty(StatusCode.MovedPermanently);
-  response.customheader("Location", format("http%s://%s%s%s", isSecure? "s": "", fqdn, request.uripath, request.query));
+  response.customheader("Location", format("http%s://%s%s%s", isSecure? "s": "", fqdn, request.path, request.query));
   response.connection = "Close";
   response.ready = true;
 }

--- a/danode/response.d
+++ b/danode/response.d
@@ -137,7 +137,7 @@ Response create(in Request request, Address address, in StatusCode statuscode = 
 void redirect(ref Response response, in Request request, in string fqdn, bool isSecure = false) {
   trace("redirecting request to %s", fqdn);
   response.payload = new Empty(StatusCode.MovedPermanently);
-  response.customheader("Location", format("http%s://%s%s%s", isSecure? "s": "", fqdn, request.path, request.query));
+  response.customheader("Location", format("http%s://%s%s%s", isSecure? "s": "", fqdn, request.uripath, request.query));
   response.connection = "Close";
   response.ready = true;
 }

--- a/danode/router.d
+++ b/danode/router.d
@@ -124,6 +124,7 @@ class Router {
     // Perform a canonical redirect of a non-existing page to the index script
     void redirectCanonical(ref Request request, ref Response response){
       trace("redirecting non-existing page (canonical url) to the index page");
+      request.page = request.uripath();
       request.url  = format("%s?%s", config.index, request.query);
       return deliver(request, response, true);
     }

--- a/danode/router.d
+++ b/danode/router.d
@@ -124,7 +124,6 @@ class Router {
     // Perform a canonical redirect of a non-existing page to the index script
     void redirectCanonical(ref Request request, ref Response response){
       trace("redirecting non-existing page (canonical url) to the index page");
-      request.page = request.uripath();
       request.url  = format("%s?%s", config.index, request.query);
       return deliver(request, response, true);
     }

--- a/danode/router.d
+++ b/danode/router.d
@@ -5,7 +5,8 @@ import danode.client : Client;
 import danode.interfaces : ClientInterface, DriverInterface, StringDriver;
 import danode.statuscode : StatusCode;
 import danode.request : Request;
-import danode.response : Response, create, serveBadRequest, domainNotFound, serveForbidden, redirect, serveCGI, serveDirectory, notFound;
+import danode.response : Response, Message, create, serveBadRequest, domainNotFound, serveForbidden, redirect, serveCGI, serveDirectory, notFound;
+import danode.payload : Message;
 import danode.files : serveStaticFile;
 import danode.webconfig : WebConfig;
 import danode.functions : from, has, isCGI, isFILE, isDIR, isAllowed, safePath;
@@ -63,6 +64,8 @@ class Router {
       trace("shorthost -> localroot: %s -> %s", request.shorthost(), localroot);
       if (request.shorthost() == "" || !exists(localroot)) return(response.domainNotFound(request));
 
+      version(SSL) { if (serveACMEChallenge(request, response)) return; }
+
       config = WebConfig(filesystem.file(localroot, "/web.config"));
       string fqdn = config.domain(request.shorthost());
       string localpath = safePath(localroot, decodeComponent(request.path));
@@ -109,6 +112,22 @@ class Router {
       trace("redirect: %s %d", config.redirect, finalrewrite);
       if(config.redirect && !finalrewrite) { return(this.redirectCanonical(request, response)); }
       return(response.notFound());  // Request is not hosted on this server
+    }
+
+    version(SSL) {
+      import danode.acme : acmeChallenges;
+
+      bool serveACMEChallenge(ref Request request, ref Response response) {
+        if (!request.isSecure && request.path.startsWith("/.well-known/acme-challenge/")) {
+          info("Router: serveACMEChallenge path: %s", request.path);
+          string token = baseName(request.path);
+          if (token in acmeChallenges) {
+            response.payload = new Message(StatusCode.Ok, acmeChallenges[token], "text/plain");
+            return(response.ready = true);
+          }
+        }
+        return(false);
+      }
     }
 
     // Expose scan() by forwarding to filesystem.scan()

--- a/danode/router.d
+++ b/danode/router.d
@@ -115,14 +115,18 @@ class Router {
     }
 
     version(SSL) {
-      import danode.acme : acmeChallenges;
+      import danode.acme : acmeChallenges, getAcmeMutex;
 
       bool serveACMEChallenge(ref Request request, ref Response response) {
         if (!request.isSecure && request.path.startsWith("/.well-known/acme-challenge/")) {
           info("Router: serveACMEChallenge path: %s", request.path);
           string token = baseName(request.path);
-          if (token in acmeChallenges) {
-            response.payload = new Message(StatusCode.Ok, acmeChallenges[token], "text/plain");
+          string keyAuth;
+          synchronized(getAcmeMutex()) {
+            if (token in acmeChallenges) keyAuth = acmeChallenges[token];
+          }
+          if (keyAuth.length) {
+            response.payload = new Message(StatusCode.Ok, keyAuth, "text/plain");
             return(response.ready = true);
           }
         }

--- a/danode/server.d
+++ b/danode/server.d
@@ -9,6 +9,7 @@ import danode.router : Router;
 import danode.log;
 
 version(SSL) {
+  import danode.acme : checkAndRenew;
   import danode.ssl : initSSL, closeSSL;
   import danode.https : HTTPS;
 }
@@ -26,14 +27,22 @@ class Server : Thread {
     Router            router;           // Router to route requests
     version(SSL) {
       Socket          sslsocket;        // SSL / HTTPs socket
+      public:
+        string certDir = ".ssl/";
+        string keyFile = ".ssl/server.key";
+        string accountKey = ".ssl/account.key";
     }
 
   public:
-    this(ushort port = 80, int backlog = 100, string wwwRoot = "./www/", int verbose = NORMAL) {
+    this(ushort port = 80, int backlog = 100, string wwwRoot = "./www/", 
+         string certDir = ".ssl/", string keyFile = ".ssl/server.key", string accountKey = ".ssl/account.key", int verbose = NORMAL) {
       this.starttime = Clock.currTime();            // Start the timer
       this.socket = initialize(port, backlog);      // Create the HTTP socket
       this.router = new Router(wwwRoot, this.socket.localAddress(), verbose);   // Start the router
       version(SSL) {
+        this.certDir = certDir;
+        this.keyFile = keyFile;
+        this.accountKey = accountKey;
         this.sslsocket = initialize(443, backlog);  // Create the SSL / HTTPs socket
       }
       set = new SocketSet(1);                       // Create a server socket set
@@ -151,8 +160,10 @@ class Server : Thread {
             else if(!client.isRunning) client.join();           // join finished threads
           }
           clients = persistent.data;
-          if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted file every day
-            router.scan(); lastScan = Clock.currTime();
+          if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted files & expiring certificates every day
+            router.scan();
+            version(SSL) { checkAndRenew(certDir, accountKey, true); }
+            lastScan = Clock.currTime();
           }
         } catch(Exception e) {
           error("Unspecified top level server error: %s", e.msg);
@@ -175,17 +186,19 @@ void parseKeyInput(ref Server server){
 
 void main(string[] args) {
   version(unittest){ ushort port = 8080; }else{ ushort port = 80; }
-  int    backlog  = 100;
-  int    verbose  = NORMAL;
-  bool   keyoff   = false;
-  string certDir  = ".ssl/";
-  string keyFile  = ".ssl/server.key";
-  string wwwRoot  = "./www/";
+  int    backlog      = 100;
+  int    verbose      = NORMAL;
+  bool   keyoff       = false;
+  string certDir      = ".ssl/";
+  string keyFile      = ".ssl/server.key";
+  string accountKey   = ".ssl/account.key";
+  string wwwRoot      = "./www/";
   getopt(args, "port|p",     &port,         // Port to listen on
                "backlog|b",  &backlog,      // Backlog of clients supported
                "keyoff|k",   &keyoff,       // Keyboard on or off
                "certDir",    &certDir,      // Location of SSL certificates
                "keyFile",    &keyFile,      // Server private key
+               "accountKey", &accountKey,   // Server Let's encrypt account key
                "wwwRoot",    &wwwRoot,      // Server www root folder
                "verbose|v",  &verbose);     // Verbose level (via commandline)
   version (unittest) {
@@ -201,15 +214,14 @@ void main(string[] args) {
       keyoff = true;
     }
 
-    auto server = new Server(port, backlog, wwwRoot, verbose);
+    auto server = new Server(port, backlog, wwwRoot, certDir, keyFile, accountKey, verbose);
     version (SSL) {
-      server.initSSL(certDir, keyFile);  // Load SSL certificates, using the server key
+      checkAndRenew(certDir, accountKey, true);
+      server.initSSL();  // Load SSL certificates, using the server key
     }
     server.start();
     while (server.running) {
-      if (!keyoff) {
-        server.parseKeyInput();
-      }
+      if (!keyoff) { server.parseKeyInput(); }
       stdout.flush();
       Thread.sleep(dur!"msecs"(250));
     }

--- a/danode/server.d
+++ b/danode/server.d
@@ -162,7 +162,7 @@ class Server : Thread {
           clients = persistent.data;
           if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted files & expiring certificates every day
             router.scan();
-            version(SSL) { checkAndRenew(certDir, accountKey, true); }
+            version(SSL) { checkAndRenew(certDir, keyFile, accountKey, true); }
             lastScan = Clock.currTime();
           }
         } catch(Exception e) {
@@ -171,9 +171,7 @@ class Server : Thread {
       }
       custom(0, "SERVER", "Server socket closed, running: %s", running);
       socket.close();
-      version (SSL) {
-        sslsocket.closeSSL();
-      }
+      version (SSL) { sslsocket.closeSSL(); }
     }
 }
 
@@ -216,7 +214,7 @@ void main(string[] args) {
 
     auto server = new Server(port, backlog, wwwRoot, certDir, keyFile, accountKey, verbose);
     version (SSL) {
-      checkAndRenew(certDir, accountKey, true);
+      checkAndRenew(certDir, keyFile, accountKey, true);
       server.initSSL();  // Load SSL certificates, using the server key
     }
     server.start();

--- a/danode/server.d
+++ b/danode/server.d
@@ -162,7 +162,7 @@ class Server : Thread {
           clients = persistent.data;
           if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted files & expiring certificates every day
             router.scan();
-            version(SSL) { checkAndRenew(certDir, keyFile, accountKey, true); }
+            version(SSL) { new Thread({ checkAndRenew(certDir, keyFile, accountKey, staging); }).start(); }
             lastScan = Clock.currTime();
           }
         } catch(Exception e) {
@@ -214,7 +214,7 @@ void main(string[] args) {
 
     auto server = new Server(port, backlog, wwwRoot, certDir, keyFile, accountKey, verbose);
     version (SSL) {
-      checkAndRenew(certDir, keyFile, accountKey, true);
+      new Thread({ checkAndRenew(certDir, keyFile, accountKey, staging); }).start();
       server.initSSL();  // Load SSL certificates, using the server key
     }
     server.start();

--- a/danode/server.d
+++ b/danode/server.d
@@ -162,7 +162,7 @@ class Server : Thread {
           clients = persistent.data;
           if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted files & expiring certificates every day
             router.scan();
-            version(SSL) { new Thread({ checkAndRenew(certDir, keyFile, accountKey, staging); }).start(); }
+            version(SSL) { new Thread({ checkAndRenew(certDir, keyFile, accountKey, true); }).start(); }
             lastScan = Clock.currTime();
           }
         } catch(Exception e) {
@@ -214,7 +214,7 @@ void main(string[] args) {
 
     auto server = new Server(port, backlog, wwwRoot, certDir, keyFile, accountKey, verbose);
     version (SSL) {
-      new Thread({ checkAndRenew(certDir, keyFile, accountKey, staging); }).start();
+      new Thread({ checkAndRenew(certDir, keyFile, accountKey, true); }).start();
       server.initSSL();  // Load SSL certificates, using the server key
     }
     server.start();

--- a/danode/server.d
+++ b/danode/server.d
@@ -162,7 +162,7 @@ class Server : Thread {
           clients = persistent.data;
           if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted files & expiring certificates every day
             router.scan();
-            version(SSL) { new Thread({ checkAndRenew(certDir, keyFile, accountKey, true); }).start(); }
+            version(SSL) { new Thread({ checkAndRenew(certDir, keyFile, accountKey); }).start(); }
             lastScan = Clock.currTime();
           }
         } catch(Exception e) {
@@ -214,7 +214,7 @@ void main(string[] args) {
 
     auto server = new Server(port, backlog, wwwRoot, certDir, keyFile, accountKey, verbose);
     version (SSL) {
-      new Thread({ checkAndRenew(certDir, keyFile, accountKey, true); }).start();
+      new Thread({ checkAndRenew(certDir, keyFile, accountKey); }).start();
       server.initSSL();  // Load SSL certificates, using the server key
     }
     server.start();

--- a/danode/server.d
+++ b/danode/server.d
@@ -162,10 +162,18 @@ class Server : Thread {
           clients = persistent.data;
           if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted files & expiring certificates every day
             router.scan();
-            version(SSL) { new Thread({ checkAndRenew(certDir, keyFile, accountKey); }).start(); }
+            version(SSL) { 
+              new Thread({
+                try { checkAndRenew(certDir, keyFile, accountKey); }
+                catch (Exception e) { error("ACME: checkAndRenew exception: %s", e.msg); }
+                catch (Error e) { error("ACME: checkAndRenew error: %s", e.msg); }
+              }).start();
+            }
             lastScan = Clock.currTime();
           }
         } catch(Exception e) {
+          error("Unspecified top level server exception: %s", e.msg);
+        } catch(Error e) {
           error("Unspecified top level server error: %s", e.msg);
         }
       }
@@ -214,7 +222,11 @@ void main(string[] args) {
 
     auto server = new Server(port, backlog, wwwRoot, certDir, keyFile, accountKey, verbose);
     version (SSL) {
-      new Thread({ checkAndRenew(certDir, keyFile, accountKey); }).start();
+      new Thread({
+        try { checkAndRenew(certDir, keyFile, accountKey); }
+        catch (Exception e) { error("ACME: checkAndRenew exception: %s", e.msg); }
+        catch (Error e) { error("ACME: checkAndRenew error: %s", e.msg); }
+      }).start();
       server.initSSL();  // Load SSL certificates, using the server key
     }
     server.start();

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -146,7 +146,8 @@ version(SSL) {
         if (hostname.length < 255) {
           string chainFile = d.name;
           info("reloading certificate at: '%s'", chainFile);
-          localContexts ~= loadContext(chainFile, hostname, keyFile);
+          auto lc = loadContext(chainFile, hostname, keyFile);
+          if (lc.context !is null) localContexts ~= lc;
         }
       }
     }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -54,7 +54,8 @@ version(SSL) {
     SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
     sslAssert(!(ctx is null));
 
-    SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+    SSL_CTX_set_cipher_list(ctx, "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305");
     SSL_CTX_set_ciphersuites(ctx, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256");
 
     if (exists(chainFile) && isFile(chainFile)) {

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -121,6 +121,7 @@ version(SSL) {
     for(size_t x = 0; x < hostname.length; x++) { ctx.hostname[x] = hostname[x]; }
     ctx.hostname[hostname.length] = '\0';
     ctx.context = createCTX(chainFile, keyFile);
+    if (ctx.context is null) { warning("HTTPS: failed to create context for %s", hostname); return ctx; }
     custom(1, "HTTPS", "context created for certificate: %s", to!string(ctx.hostname.ptr));
     SSL_CTX_callback_ctrl(ctx.context,SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cast(ExternC!(void function())) &switchContext);
     return(ctx);

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -129,27 +129,28 @@ version(SSL) {
   // loads all crt files in the certDir, using keyfile: server.key
   void initSSL(Server server, VERSION v = SSL23) {
     custom(0, "HTTPS", "loading Deimos.openSSL, certDir: %s, keyFile: %s, SSL:%s", server.certDir, server.keyFile, v);
-    custom(0, "HTTPS", "certificate folder, exists: %d", exists(server.certDir));
+    reloadSSL(server.certDir, server.keyFile);
+  }
 
-    if (!exists(server.certDir)) { warning("SSL certificate folder '%s' not found", server.certDir); return; }
-    if (!isDir(server.certDir)) { warning("SSL certificate folder '%s' not a folder", server.certDir); return; }
-    if (!exists(server.keyFile)) { warning("SSL private key file: '%s' not found", server.keyFile); return; }
-    if (!isFile(server.keyFile)) { warning("SSL private key file: '%s' not a file", server.keyFile); return; }
+  // Reload all SSL contexts from certDir without restarting the server
+  void reloadSSL(string certDir = ".ssl/", string keyFile = ".ssl/server.key") {
+    custom(0, "HTTPS", "(re)loading SSL certificates from: %s", certDir);
+    if (!exists(certDir) || !isDir(certDir)) { warning("SSL cert dir '%s' not found", certDir); return; }
+    if (!exists(keyFile) || !isFile(keyFile)) { warning("SSL key file '%s' not found", keyFile); return; }
 
     SSLcontext[] localContexts;
-    foreach (DirEntry d; dirEntries(server.certDir, SpanMode.shallow)) {
+    foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
       if (d.name.endsWith(".crt")) {
         string hostname = baseName(d.name, ".crt");
         if (hostname.length < 255) {
-          string chainFile = ".ssl/" ~ baseName(d.name, ".crt") ~ ".chain";
-          info("loading certificate at: '%s', chain from: '%s'", d.name, chainFile);
-          localContexts ~= loadContext(d.name, hostname, server.keyFile, chainFile);
-          custom(1, "HTTPS", "stored certificate: %s in context: %d", to!string(localContexts[$-1].hostname.ptr), localContexts.length-1);
+          string chainFile = certDir ~ baseName(d.name, ".crt") ~ ".chain";
+          info("reloading certificate at: '%s', chain from: '%s'", d.name, chainFile);
+          localContexts ~= loadContext(d.name, hostname, keyFile, chainFile);
         }
       }
     }
-    contexts = localContexts;  // single assignment after all certs loaded
-    custom(0, "HTTPS", "loaded %s SSL certificates", contexts.length);
+    contexts = localContexts;  // atomic single assignment
+    custom(0, "HTTPS", "(re)loaded %s SSL certificates", contexts.length);
   }
 
   // Close the server SSL socket, and clean up the different contexts

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -57,6 +57,7 @@ version(SSL) {
     SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
     SSL_CTX_set_cipher_list(ctx, "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305");
     SSL_CTX_set_ciphersuites(ctx, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256");
+    SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
     SSL_CTX_set1_groups_list(ctx, "X25519:P-256:P-384");
 
     if (exists(chainFile) && isFile(chainFile)) {

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -140,12 +140,13 @@ version(SSL) {
 
     SSLcontext[] localContexts;
     foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
-      if (d.name.endsWith(".crt")) {
-        string hostname = baseName(d.name, ".crt");
+      if (d.name.endsWith(".chain")) {
+        string hostname = baseName(d.name, ".chain");
         if (hostname.length < 255) {
-          string chainFile = certDir ~ baseName(d.name, ".crt") ~ ".chain";
-          info("reloading certificate at: '%s', chain from: '%s'", d.name, chainFile);
-          localContexts ~= loadContext(d.name, hostname, keyFile, chainFile);
+          string chainFile = d.name;
+          string certFile  = certDir ~ hostname ~ ".crt"; // fallback if no chain
+          info("reloading certificate at: '%s'", chainFile);
+          localContexts ~= loadContext(certFile, hostname, keyFile, chainFile);
         }
       }
     }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -65,6 +65,7 @@ version(SSL) {
       sslAssert(SSL_CTX_use_certificate_chain_file(ctx, cast(const char*) toStringz(chainFile)) > 0);
     } else {
       custom(1, "WARN", "No chain file for %s", chainFile);
+      return(null);
     }
     sslAssert(SSL_CTX_use_PrivateKey_file(ctx, cast(const char*) toStringz(keyFile), 1) > 0);
     sslAssert(SSL_CTX_check_private_key(ctx) > 0);
@@ -125,7 +126,7 @@ version(SSL) {
     return(ctx);
   }
 
-  // loads all crt files in the certDir, using keyfile: server.key
+  // loads all chain files in the server.certDir, using server.keyFile
   void initSSL(Server server, VERSION v = SSL23) {
     custom(0, "HTTPS", "loading Deimos.openSSL, certDir: %s, keyFile: %s, SSL:%s", server.certDir, server.keyFile, v);
     reloadSSL(server.certDir, server.keyFile);

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -57,7 +57,7 @@ version(SSL) {
     SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
     SSL_CTX_set_cipher_list(ctx, "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305");
     SSL_CTX_set_ciphersuites(ctx, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256");
-    SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+    SSL_CTX_set_options(ctx, 0x00400000U); //SSL_OP_CIPHER_SERVER_PREFERENCE
     SSL_CTX_set1_groups_list(ctx, "X25519:P-256:P-384");
 
     if (exists(chainFile) && isFile(chainFile)) {

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -3,8 +3,7 @@ module danode.ssl;
 import danode.log : custom, warning, info;
 
 version(SSL) {
-  import deimos.openssl.ssl;
-  import deimos.openssl.err;
+  import danode.includes;
 
   import danode.imports;
   import danode.client;
@@ -64,18 +63,16 @@ version(SSL) {
 
   // Create a new SSL context pointer using a certificate, chain and privateKey file
   SSL_CTX* createCTX(string certFile, string keyFile, string chainFile) {
-    SSL_CTX* ctx = SSL_CTX_new(TLSv1_2_server_method());
-    //SSL_CTX* ctx = SSL_CTX_new(SSLv3_server_method());
-
+    SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
     sslAssert(!(ctx is null));
-    SSL_CTX_clear_options(ctx, SSL_OP_LEGACY_SERVER_CONNECT);
+
     SSL_CTX_set_cipher_list(ctx, "HIGH:!ADH:!LOW:!EXP:!MD5:!RC4:!AES128:!CAMELLIA:@STRENGTH");
-    sslAssert(SSL_CTX_use_certificate_file(ctx, cast(const char*) toStringz(certFile), SSL_FILETYPE_PEM) > 0);
+    sslAssert(SSL_CTX_use_certificate_file(ctx, cast(const char*) toStringz(certFile), 1) > 0);
     if (exists(chainFile) && isFile(chainFile)) {
       custom(1, "HTTPS", "loading certificate chain from file: %s", chainFile);
       sslAssert(SSL_CTX_use_certificate_chain_file(ctx, cast(const char*) toStringz(chainFile)) > 0);
     } else { info("chain not loaded: %s", chainFile); }
-    sslAssert(SSL_CTX_use_PrivateKey_file(ctx, cast(const char*) toStringz(keyFile), SSL_FILETYPE_PEM) > 0);
+    sslAssert(SSL_CTX_use_PrivateKey_file(ctx, cast(const char*) toStringz(keyFile), 1) > 0);
     sslAssert(SSL_CTX_check_private_key(ctx) > 0);
     return ctx;
   }
@@ -173,7 +170,7 @@ version(SSL) {
   }
 
   void sslAssert(bool ret) { 
-    if (!ret) { ERR_print_errors_fp(stderr.getFP()); throw new Exception("SSL_ERROR"); }
+    if (!ret) { ERR_print_errors_fp(null); throw new Exception("SSL_ERROR"); }
   }
 
   unittest {

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -57,6 +57,7 @@ version(SSL) {
     SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
     SSL_CTX_set_cipher_list(ctx, "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305");
     SSL_CTX_set_ciphersuites(ctx, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256");
+    SSL_CTX_set1_groups_list(ctx, "X25519:P-256:P-384");
 
     if (exists(chainFile) && isFile(chainFile)) {
       custom(1, "HTTPS", "loading certificate+chain from file: %s", chainFile);

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -50,7 +50,7 @@ version(SSL) {
   }
 
   // Create a new SSL context pointer using a certificate, chain and privateKey file
-  SSL_CTX* createCTX(string certFile, string keyFile, string chainFile) {
+  SSL_CTX* createCTX(string chainFile, string keyFile) {
     SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
     sslAssert(!(ctx is null));
 
@@ -64,8 +64,7 @@ version(SSL) {
       custom(1, "HTTPS", "loading certificate+chain from file: %s", chainFile);
       sslAssert(SSL_CTX_use_certificate_chain_file(ctx, cast(const char*) toStringz(chainFile)) > 0);
     } else {
-      custom(1, "HTTPS", "loading certificate from file: %s", certFile);
-      sslAssert(SSL_CTX_use_certificate_file(ctx, cast(const char*) toStringz(certFile), 1) > 0);
+      custom(1, "WARN", "No chain file for %s", chainFile);
     }
     sslAssert(SSL_CTX_use_PrivateKey_file(ctx, cast(const char*) toStringz(keyFile), 1) > 0);
     sslAssert(SSL_CTX_check_private_key(ctx) > 0);
@@ -115,12 +114,12 @@ version(SSL) {
     return(err);
   }
 
-  // loads an SSL context for hostname from the .crt file at path;
-  SSLcontext loadContext(string path, string hostname, string keyFile, string chainFile) {
+  // loads an SSL context for hostname from the .chain file at path;
+  SSLcontext loadContext(string chainFile, string hostname, string keyFile) {
     SSLcontext ctx;
     for(size_t x = 0; x < hostname.length; x++) { ctx.hostname[x] = hostname[x]; }
     ctx.hostname[hostname.length] = '\0';
-    ctx.context = createCTX(path, keyFile, chainFile);
+    ctx.context = createCTX(chainFile, keyFile);
     custom(1, "HTTPS", "context created for certificate: %s", to!string(ctx.hostname.ptr));
     SSL_CTX_callback_ctrl(ctx.context,SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cast(ExternC!(void function())) &switchContext);
     return(ctx);
@@ -144,9 +143,8 @@ version(SSL) {
         string hostname = baseName(d.name, ".chain");
         if (hostname.length < 255) {
           string chainFile = d.name;
-          string certFile  = certDir ~ hostname ~ ".crt"; // fallback if no chain
           info("reloading certificate at: '%s'", chainFile);
-          localContexts ~= loadContext(certFile, hostname, keyFile, chainFile);
+          localContexts ~= loadContext(chainFile, hostname, keyFile);
         }
       }
     }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -127,23 +127,23 @@ version(SSL) {
   }
 
   // loads all crt files in the certDir, using keyfile: server.key
-  void initSSL(Server server, string certDir = ".ssl/", string keyFile = ".ssl/server.key", VERSION v = SSL23) {
-    custom(0, "HTTPS", "loading Deimos.openSSL, certDir: %s, keyFile: %s, SSL:%s", certDir, keyFile, v);
-    custom(0, "HTTPS", "certificate folder: %d", exists(certDir));
+  void initSSL(Server server, VERSION v = SSL23) {
+    custom(0, "HTTPS", "loading Deimos.openSSL, certDir: %s, keyFile: %s, SSL:%s", server.certDir, server.keyFile, v);
+    custom(0, "HTTPS", "certificate folder, exists: %d", exists(server.certDir));
 
-    if (!exists(certDir)) { warning("SSL certificate folder '%s' not found", certDir); return; }
-    if (!isDir(certDir)) { warning("SSL certificate folder '%s' not a folder", certDir); return; }
-    if (!exists(keyFile)) { warning("SSL private key file: '%s' not found", certDir); return; }
-    if (!isFile(keyFile)) { warning("SSL private key file: '%s' not a file", certDir); return; }
+    if (!exists(server.certDir)) { warning("SSL certificate folder '%s' not found", server.certDir); return; }
+    if (!isDir(server.certDir)) { warning("SSL certificate folder '%s' not a folder", server.certDir); return; }
+    if (!exists(server.keyFile)) { warning("SSL private key file: '%s' not found", server.keyFile); return; }
+    if (!isFile(server.keyFile)) { warning("SSL private key file: '%s' not a file", server.keyFile); return; }
 
     SSLcontext[] localContexts;
-    foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
+    foreach (DirEntry d; dirEntries(server.certDir, SpanMode.shallow)) {
       if (d.name.endsWith(".crt")) {
         string hostname = baseName(d.name, ".crt");
         if (hostname.length < 255) {
           string chainFile = ".ssl/" ~ baseName(d.name, ".crt") ~ ".chain";
           info("loading certificate at: '%s', chain from: '%s'", d.name, chainFile);
-          localContexts ~= loadContext(d.name, hostname, keyFile, chainFile);
+          localContexts ~= loadContext(d.name, hostname, server.keyFile, chainFile);
           custom(1, "HTTPS", "stored certificate: %s in context: %d", to!string(localContexts[$-1].hostname.ptr), localContexts.length-1);
         }
       }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -57,11 +57,13 @@ version(SSL) {
     SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
     SSL_CTX_set_ciphersuites(ctx, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256");
 
-    sslAssert(SSL_CTX_use_certificate_file(ctx, cast(const char*) toStringz(certFile), 1) > 0);
     if (exists(chainFile) && isFile(chainFile)) {
-      custom(1, "HTTPS", "loading certificate chain from file: %s", chainFile);
+      custom(1, "HTTPS", "loading certificate+chain from file: %s", chainFile);
       sslAssert(SSL_CTX_use_certificate_chain_file(ctx, cast(const char*) toStringz(chainFile)) > 0);
-    } else { info("chain not loaded: %s", chainFile); }
+    } else {
+      custom(1, "HTTPS", "loading certificate from file: %s", certFile);
+      sslAssert(SSL_CTX_use_certificate_file(ctx, cast(const char*) toStringz(certFile), 1) > 0);
+    }
     sslAssert(SSL_CTX_use_PrivateKey_file(ctx, cast(const char*) toStringz(keyFile), 1) > 0);
     sslAssert(SSL_CTX_check_private_key(ctx) > 0);
     return ctx;

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -10,18 +10,6 @@ version(SSL) {
   import danode.server : Server;
   import danode.response : Response;
 
-  static if (OPENSSL_VERSION_NUMBER < 0x10100000L) {
-      // OpenSSL 1.0.x - real functions exist, nothing to shim
-  } else {
-    //--- Add shims for OpenSSL 1.1, from: https://github.com/CyberShadow/ae
-    alias SSLv3_server_method = TLSv1_server_method;
-    struct OPENSSL_INIT_SETTINGS;
-    extern(C) void OPENSSL_init_ssl(ulong opts, const OPENSSL_INIT_SETTINGS *settings) nothrow;
-    void SSL_library_init() { OPENSSL_init_ssl(0, null); }
-    void OpenSSL_add_all_algorithms() { SSL_library_init(); }
-    void SSL_load_error_strings() {}
-  }
-
   // SSL context structure, stored relation between hostname 
   // and the SSL context, should be allocated only once available to C, and deallocated at exit
   struct SSLcontext {
@@ -66,7 +54,9 @@ version(SSL) {
     SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
     sslAssert(!(ctx is null));
 
-    SSL_CTX_set_cipher_list(ctx, "HIGH:!ADH:!LOW:!EXP:!MD5:!RC4:!AES128:!CAMELLIA:@STRENGTH");
+    SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+    SSL_CTX_set_ciphersuites(ctx, "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256");
+
     sslAssert(SSL_CTX_use_certificate_file(ctx, cast(const char*) toStringz(certFile), 1) > 0);
     if (exists(chainFile) && isFile(chainFile)) {
       custom(1, "HTTPS", "loading certificate chain from file: %s", chainFile);
@@ -134,9 +124,6 @@ version(SSL) {
   // loads all crt files in the certDir, using keyfile: server.key
   void initSSL(Server server, string certDir = ".ssl/", string keyFile = ".ssl/server.key", VERSION v = SSL23) {
     custom(0, "HTTPS", "loading Deimos.openSSL, certDir: %s, keyFile: %s, SSL:%s", certDir, keyFile, v);
-    SSL_library_init();
-    OpenSSL_add_all_algorithms();
-    SSL_load_error_strings();
     custom(0, "HTTPS", "certificate folder: %d", exists(certDir));
 
     if (!exists(certDir)) { warning("SSL certificate folder '%s' not found", certDir); return; }

--- a/deps/README.md
+++ b/deps/README.md
@@ -1,0 +1,27 @@
+Build OpenSSL for Windows (or linux)
+------------------------------------
+
+##### Windows
+Download the requirements:
+- [Strawberry Perl](https://strawberryperl.com/)
+- [NASM](https://www.nasm.us/)
+
+Compile OpenSSL:
+```
+call "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build/vcvars64.bat" 
+cd deps/openssl
+perl Configure VC-WIN64A
+nmake
+```
+
+##### Linux
+Install requirements:
+```bash
+sudo apt-get install build-essential
+```
+Compile OpenSSL:
+```bash
+cd deps/openssl
+./Configure linux-x86_64
+make
+```

--- a/deps/README.md
+++ b/deps/README.md
@@ -1,5 +1,10 @@
 Build OpenSSL for Windows (or linux)
 ------------------------------------
+Clone the repository, or update submodules
+```bash
+git clone --recursive https://github.com/DannyArends/DaNode.git
+git submodule update --init --recursive
+```
 
 ##### Windows
 Download the requirements:
@@ -7,7 +12,7 @@ Download the requirements:
 - [NASM](https://www.nasm.us/)
 
 Compile OpenSSL:
-```
+```cmd
 call "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build/vcvars64.bat" 
 cd deps/openssl
 perl Configure VC-WIN64A

--- a/dub.json
+++ b/dub.json
@@ -6,7 +6,7 @@
 	"importPaths": ["danode"],
 	"sourcePaths": ["danode"],
 	"mainSourceFile": "danode/server.d",
-	"targetPath": "danode",
+	"targetPath": "bin",
 	"targetName": "server",
 	"configurations": [
 	{
@@ -17,9 +17,12 @@
 		"name": "ssl",
 		"targetType": "executable",
 		"versions": ["SSL"],
-		"lflags-windows-x86_64": ["/LIBPATH:C:/OpenSSL-Win64/lib"],
+		"dflags": ["-P-I$PACKAGE_DIR/deps/openssl/include"],
+		"lflags-linux-x86_64": ["-L$PACKAGE_DIR/deps/openssl"],
+		"libs-linux-x86_64": ["ssl", "crypto"],
+		"lflags-windows-x86_64": ["/LIBPATH:$PACKAGE_DIR/deps/openssl"],
 		"libs-windows-x86_64": ["libssl", "libcrypto"],
-		"dependencies": {"openssl": "~>3.4.0"}
+		"copyFiles-windows-x86_64": ["deps/openssl/libssl-3-x64.dll", "deps/openssl/libcrypto-3-x64.dll"]
 	}
 	]
 }

--- a/dub.json
+++ b/dub.json
@@ -18,7 +18,7 @@
 		"targetType": "executable",
 		"versions": ["SSL"],
 		"dflags": ["-P-I$PACKAGE_DIR/deps/openssl/include"],
-		"lflags-linux-x86_64": ["-L$PACKAGE_DIR/deps/openssl"],
+		"lflags-linux-x86_64": ["-L$PACKAGE_DIR/deps/openssl", "-rpath=$PACKAGE_DIR/deps/openssl"],
 		"libs-linux-x86_64": ["ssl", "crypto"],
 		"lflags-windows-x86_64": ["/LIBPATH:$PACKAGE_DIR/deps/openssl"],
 		"libs-windows-x86_64": ["libssl", "libcrypto"],

--- a/sh/decodeKey.py
+++ b/sh/decodeKey.py
@@ -1,0 +1,18 @@
+import json, base64
+from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateNumbers, rsa_crt_iqmp, rsa_crt_dmp1, rsa_crt_dmq1
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+from cryptography.hazmat.backends import default_backend
+
+def b64d(s):
+    s += '=' * (-len(s) % 4)
+    return int.from_bytes(base64.urlsafe_b64decode(s), 'big')
+
+jwk = json.load(open('account_jwk.json'))
+nums = RSAPrivateNumbers(b64d(jwk['p']), b64d(jwk['q']), b64d(jwk['d']),
+       rsa_crt_dmp1(b64d(jwk['d']), b64d(jwk['p'])),
+       rsa_crt_dmq1(b64d(jwk['d']), b64d(jwk['q'])),
+       rsa_crt_iqmp(b64d(jwk['p']), b64d(jwk['q'])),
+       RSAPublicNumbers(b64d(jwk['e']), b64d(jwk['n'])))
+key = nums.private_key(default_backend())
+print(key.private_bytes(Encoding.PEM, PrivateFormat.TraditionalOpenSSL, NoEncryption()).decode())

--- a/sh/pid
+++ b/sh/pid
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-if pgrep -f 'danode/server' >/dev/null 2>&1
+if pgrep -f 'bin/server' >/dev/null 2>&1
   then
      echo "Running"
   else
      echo "Down, restarting"
      cd /home/danny/Github/DaNode/
-     nohup authbind bin/server -k -b 100 -v 2 > server.log 2>&1 &
+     nohup authbind bin/server -k -b 100 -v 0 > server.log 2>&1 &
      date >> /home/danny/restarts.txt
 fi
 

--- a/sh/pid
+++ b/sh/pid
@@ -6,7 +6,7 @@ if pgrep -f 'danode/server' >/dev/null 2>&1
   else
      echo "Down, restarting"
      cd /home/danny/Github/DaNode/
-     nohup authbind danode/server -k -b 100 -v 2 > server.log 2>&1 &
+     nohup authbind bin/server -k -b 100 -v 2 > server.log 2>&1 &
      date >> /home/danny/restarts.txt
 fi
 

--- a/sh/run
+++ b/sh/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 rm -rf server.log
-nohup authbind danode/server -k -b 100 -v 0 > server.log 2>&1 &
+nohup authbind bin/server -k -b 100 -v 0 > server.log 2>&1 &
 

--- a/sh/stop
+++ b/sh/stop
@@ -1,1 +1,1 @@
-kill -9 `ps -ef | grep danode/server | grep -v grep | awk '{print $2}'`
+kill -9 `ps -ef | grep bin/server | grep -v grep | awk '{print $2}'`


### PR DESCRIPTION
### ACME Auto-Renewal

-Implemented full RFC 8555 ACME client in danode/acme.d using ImportC + OpenSSL 3.x
-Supports HTTP-01 challenge served directly by the router (no certbot dependency)
-Auto-detects expiring certs (<30 days) and bootstraps missing certs from .ssl/*.csr files
-Hot-reloads SSL contexts after renewal without server restart
-Runs renewal in background thread to avoid blocking the main server loop
-Account key loaded from PEM converted from certbot JWK (sh/decodeKey.py)
-Staging/production toggle via staging parameter in checkAndRenew

### OpenSSL

-Added OpenSSL 3.x as git submodule in deps/openssl
-Replaced deimos D bindings with ImportC (danode/includes.c)
-Build instructions for Windows (MSVC) and Linux in deps/README.md
-Windows: links against DLLs with copyFiles, Linux: shared libs with rpath

### TLS Hardening

-TLS 1.2/1.3 only, dropped older protocols
-Modern cipher suites: TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256, ECDHE-RSA-AES256-GCM-SHA384
-Server-preferred ECDH group order: X25519, P-256, P-384
-Proper TLS 1.3 close_notify shutdown
-Chain-only cert loading — no separate .crt files needed
-**Achieves A+ on SSL Labs**

### Bug Fixes

-Fixed "%A" format specifier crash from user-supplied URLs in log output
-Fixed REQUEST_DIR/REMOTE_PAGE regression causing spaces-in-URL 404s
-Fixed SSL handshake/abort log noise demoted to verbose level 2
-Fixed sh/pid process name to match new bin/server output path