### PR TITLE
Development

### DIFF
--- a/danode/acme.d
+++ b/danode/acme.d
@@ -6,7 +6,7 @@ version(SSL) {
 
   import danode.log : acme, acmeError, Level;
   import danode.ssl : loadSSL, generateKey;
-  import danode.functions : writeinfile;
+  import danode.functions : writeFile;
 
   immutable string ACME_DIR_PROD    = "https://acme-v02.api.letsencrypt.org/directory";
   immutable string ACME_DIR_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
@@ -161,7 +161,7 @@ version(SSL) {
     http.onReceive = (ubyte[] data) { response ~= cast(char[]) data; return data.length; };
     http.perform();
 
-    writeinfile(certPath, cast(string) response);
+    certPath.writeFile(cast(string) response);
     acme(Level.Verbose, "ACME: certificate saved to %s", certPath);
     return true;
   }

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -3,6 +3,7 @@ module danode.acme;
 version(SSL) {
   import danode.imports;
   import danode.includes;
+
   import danode.log : info, warning, error;
   import danode.ssl : reloadSSL;
   import danode.functions : writeinfile;
@@ -12,10 +13,8 @@ version(SSL) {
 
   __gshared string[string] acmeChallenges; // Shared challenge store: token -> keyAuthorization
   __gshared Mutex acmeMutex;
-  Mutex getAcmeMutex() {
-    if (acmeMutex is null) acmeMutex = new Mutex();
-    return acmeMutex;
-  }
+
+  Mutex getAcmeMutex() { if (acmeMutex is null) { acmeMutex = new Mutex(); } return acmeMutex; }
 
   // POST a JWS request to an ACME URL and return parsed JSON response
   JSONValue acmePost(EVP_PKEY* pkey, JSONValue dir, string url, string kid, string payload,

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -4,8 +4,8 @@ version(SSL) {
   import danode.imports;
   import danode.includes;
 
-  import danode.log : info, warning, error;
-  import danode.ssl : reloadSSL;
+  import danode.log : acme, acmeError, Level;
+  import danode.ssl : loadSSL, generateKey;
   import danode.functions : writeinfile;
 
   immutable string ACME_DIR_PROD    = "https://acme-v02.api.letsencrypt.org/directory";
@@ -33,25 +33,25 @@ version(SSL) {
       };
     }
     http.perform();
-    info("ACME: POST %s -> %s", url, cast(string) response);
+    acme(Level.Trace, "ACME: POST %s -> %s", url, cast(string) response);
     return parseJSON(response);
   }
 
   // Full ACME renewal flow
   bool renewCert(string domain, string email, string csrPath, string chainPath, string accountKey, bool staging) {
-    info("ACME: starting renewal for %s", domain);
+    acme(Level.Always, "ACME: starting renewal for %s", domain);
 
     EVP_PKEY* pkey = loadAccountKey(accountKey);
     if (pkey is null) return false;
 
     JSONValue dir = acmeDirectory(staging);
     string kid = acmeAccountURL(dir, pkey, email);
-    if (kid.length == 0) { error("ACME: failed to get account URL"); return false; }
-    info("ACME: account URL: %s", kid);
+    if (kid.length == 0) { acmeError("ACME: failed to get account URL"); return false; }
+    acme(Level.Verbose, "Account URL: %s", kid);
 
     string orderURL;
     JSONValue order = newOrder(dir, pkey, kid, domain, orderURL);
-    info("ACME: order: %s, orderURL: %s", order.toString(), orderURL);
+    acme(Level.Verbose, "ACME: order: %s, orderURL: %s", order.toString(), orderURL);
     string[] tokens;
     foreach (authURL; order["authorizations"].array) {
       JSONValue challenge = getHTTP01Challenge(authURL.str, dir, pkey, kid);
@@ -67,7 +67,7 @@ version(SSL) {
     foreach (t; tokens) synchronized(getAcmeMutex()) { acmeChallenges.remove(t); }
 
     JSONValue finalized = finalizeOrder(order, dir, pkey, kid, csrPath);
-    info("ACME: order status: %s, finalized: %s", finalized["status"].str, finalized.toString());
+    acme(Level.Verbose, "ACME: order status: %s, finalized: %s", finalized["status"].str, finalized.toString());
 
     foreach (i; 0 .. 10) { // Poll until certificate is ready
       if (finalized["status"].str == "valid") break;
@@ -79,16 +79,17 @@ version(SSL) {
 
     // Check cert expiry and renew if < 30 days remaining
   void checkAndRenew(string certDir = ".ssl/", string keyFile = ".ssl/server.key", string accountKey = ".ssl/account.key", bool staging = false) {
+    if (!exists(accountKey) || !isFile(accountKey)) { accountKey.generateKey(); }
     new Thread({
       try {
-        info("ACME: checkAndRenew called on '%s' with key '%s'", certDir, accountKey);
+        acme(Level.Always, "checkAndRenew called on '%s' with key '%s'", certDir, accountKey);
         foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
           if (!d.name.endsWith(".csr")) continue;
           string domain = baseName(d.name, ".csr");
           string chainPath = certDir ~ domain ~ ".chain";
 
-          if (!exists(chainPath)) { info("ACME: no chain found for %s, bootstrapping", domain);
-            if (renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)) { reloadSSL(certDir, keyFile); }
+          if (!exists(chainPath)) { acme(Level.Always, "ACME: no chain found for %s, bootstrapping", domain);
+            if (renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
             continue;
           }
 
@@ -102,14 +103,14 @@ version(SSL) {
           ASN1_TIME_diff(&days, &secs, null, notAfter);
           X509_free(cert);
 
-          info("ACME: chain %s expires in %d days", domain, days);
-          if (days < 30) { info("ACME: renewing chain for %s", domain);
-            if (renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)) { reloadSSL(certDir, keyFile); }
+          acme(Level.Verbose, "ACME: chain %s expires in %d days", domain, days);
+          if (days < 30) { acme(Level.Verbose, "ACME: renewing chain for %s", domain);
+            if (renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
           }
         }
       }
-      catch (Exception e) { error("ACME: checkAndRenew exception: %s", e.msg); }
-      catch (Error e) { error("ACME: checkAndRenew error: %s", e.msg); }
+      catch (Exception e) { acmeError("ACME: checkAndRenew exception: %s", e.msg); }
+      catch (Error e) { acmeError("ACME: checkAndRenew error: %s", e.msg); }
     }).start();
   }
 
@@ -124,7 +125,7 @@ version(SSL) {
     string token = challenge["token"].str;
     string keyAuth = token ~ "." ~ jwkThumbprint(pkey);
     synchronized(getAcmeMutex()) { acmeChallenges[token] = keyAuth; }
-    info("ACME: challenge token: %s", token);
+    acme(Level.Trace, "ACME: challenge token: %s", token);
     return token;
   }
 
@@ -133,7 +134,7 @@ version(SSL) {
     // Load CSR from file
     BIO* bio = BIO_new_file(toStringz(csrPath), "r");
     X509_REQ* req = PEM_read_bio_X509_REQ(bio, null, null, null);
-    if (req is null) { error("ACME: failed to load CSR from %s", csrPath); return JSONValue.init; }
+    if (req is null) { acmeError("ACME: failed to load CSR from %s", csrPath); return JSONValue.init; }
     BIO_free(bio);
 
     // Convert CSR to DER
@@ -161,7 +162,7 @@ version(SSL) {
     http.perform();
 
     writeinfile(certPath, cast(string) response);
-    info("ACME: certificate saved to %s", certPath);
+    acme(Level.Verbose, "ACME: certificate saved to %s", certPath);
     return true;
   }
 
@@ -178,13 +179,13 @@ version(SSL) {
       foreach (authURL; order["authorizations"].array) {
         JSONValue auth = acmePost(pkey, dir, authURL.str, kid, "");
         string status = auth["status"].str;
-        info("ACME: authorization status for %s: %s", authURL.str, status);
-        if (status == "invalid") { error("ACME: authorization failed"); return false; }
+        acme(Level.Verbose, "ACME: authorization status for %s: %s", authURL.str, status);
+        if (status == "invalid") { acmeError("ACME: authorization failed"); return false; }
         if (status != "valid") allValid = false;
       }
       if (allValid) return true;
     }
-    error("ACME: authorization timed out");
+    acmeError("ACME: authorization timed out");
     return false;
   }
 
@@ -197,7 +198,7 @@ version(SSL) {
   JSONValue getHTTP01Challenge(string authURL, JSONValue dir, EVP_PKEY* pkey, string kid) {
     JSONValue auth = acmePost(pkey, dir, authURL, kid, "");
     foreach (challenge; auth["challenges"].array) { if (challenge["type"].str == "http-01") return challenge; }
-    error("ACME: no HTTP-01 challenge found");
+    acmeError("ACME: no HTTP-01 challenge found");
     return JSONValue.init;
   }
 
@@ -244,7 +245,7 @@ version(SSL) {
   string acmeAccountURL(JSONValue dir, EVP_PKEY* pkey, string email) {
     string kid;
     acmePost(pkey, dir, dir["newAccount"].str, "", `{"termsOfServiceAgreed":true,"onlyReturnExisting":true,"contact":["mailto:` ~ email ~ `"]}`, &kid);
-    info("ACME: kid: %s", kid);
+    acme(Level.Verbose, "ACME: kid: %s", kid);
     return kid;
   }
 
@@ -272,15 +273,15 @@ version(SSL) {
   // Sign data with RS256 using the account key
   ubyte[] signRS256(EVP_PKEY* pkey, const(ubyte)[] data) {
     EVP_MD_CTX* ctx = EVP_MD_CTX_new();
-    if (ctx is null) { error("ACME: EVP_MD_CTX_new failed"); return null; }
+    if (ctx is null) { acmeError("ACME: EVP_MD_CTX_new failed"); return null; }
     scope(exit) EVP_MD_CTX_free(ctx);
 
-    if (EVP_DigestSignInit(ctx, null, EVP_sha256(), null, pkey) <= 0) { error("ACME: EVP_DigestSignInit failed"); return null; }
-    if (EVP_DigestSignUpdate(ctx, data.ptr, data.length) <= 0) { error("ACME: EVP_DigestSignUpdate failed"); return null; }
+    if (EVP_DigestSignInit(ctx, null, EVP_sha256(), null, pkey) <= 0) { acmeError("ACME: EVP_DigestSignInit failed"); return null; }
+    if (EVP_DigestSignUpdate(ctx, data.ptr, data.length) <= 0) { acmeError("ACME: EVP_DigestSignUpdate failed"); return null; }
     size_t siglen;
-    if (EVP_DigestSignFinal(ctx, null, &siglen) <= 0) { error("ACME: EVP_DigestSignFinal (len) failed"); return null; }
+    if (EVP_DigestSignFinal(ctx, null, &siglen) <= 0) { acmeError("ACME: EVP_DigestSignFinal (len) failed"); return null; }
     ubyte[] sig = new ubyte[](siglen);
-    if (EVP_DigestSignFinal(ctx, sig.ptr, &siglen) <= 0) { error("ACME: EVP_DigestSignFinal failed"); return null; }
+    if (EVP_DigestSignFinal(ctx, sig.ptr, &siglen) <= 0) { acmeError("ACME: EVP_DigestSignFinal failed"); return null; }
     return sig[0 .. siglen];
   }
 
@@ -301,11 +302,11 @@ version(SSL) {
 
   EVP_PKEY* loadAccountKey(string path = ".ssl/account.key") {
     BIO* bio = BIO_new_file(toStringz(path), "r");
-    if (bio is null) { error("ACME: cannot open account key: %s", path); return null; }
+    if (bio is null) { acmeError("ACME: cannot open account key: %s", path); return null; }
     EVP_PKEY* pkey = PEM_read_bio_PrivateKey(bio, null, null, null);
     BIO_free(bio);
-    if (pkey is null) { error("ACME: failed to parse account key"); return null; }
-    info("ACME: account key loaded from %s", path);
+    if (pkey is null) { acmeError("ACME: failed to parse account key"); return null; }
+    acme(Level.Always, "ACME: account key loaded from %s", path);
     return pkey;
   }
 }

--- a/danode/client.d
+++ b/danode/client.d
@@ -4,11 +4,12 @@ import danode.imports;
 import danode.cgi : CGI;
 import danode.router : Router, runRequest;
 import danode.statuscode : StatusCode;
+import danode.functions: htmltime, Msecs;
 import danode.interfaces : DriverInterface, ClientInterface, StringDriver;
 import danode.response : Response, setPayload;
 import danode.request : Request;
 import danode.payload : Message, PayloadType;
-import danode.log : custom, info, trace, warning, NOTSET, NORMAL;
+import danode.log : log, req, tag, error, Level;
 
 immutable size_t MAX_HEADER_SIZE  = 1024 * 32;          //  32KB Header
 immutable size_t MAX_REQUEST_SIZE = 1024 * 1024 * 2;    //   2MB Body
@@ -23,7 +24,7 @@ class Client : Thread, ClientInterface {
 
   public:
     this(Router router, DriverInterface driver, long maxtime = 5000) {
-      custom(3, "CLIENT", "client constructor");
+      log(Level.Trace, "client constructor");
       this.router = router;
       this.driver = driver;
       this.maxtime = maxtime;
@@ -31,9 +32,9 @@ class Client : Thread, ClientInterface {
     }
 
    final void run() {
-      trace("new connection established %s:%d", ip(), port() );
+      log(Level.Trace, "New connection established %s:%d", ip(), port() );
       try {
-        if (driver.openConnection() == false) { custom(2, "WARN", "new connection aborted: unable to open connection"); stop(); }
+        if (driver.openConnection() == false) { log(Level.Verbose, "WARN: Unable to open connection"); stop(); }
         Request request;
         Response response;
         scope (exit) {
@@ -45,28 +46,26 @@ class Client : Thread, ClientInterface {
           if (driver.receive(driver.socket) > 0) {     // We've received new data
             if (!driver.hasHeader()) {
               if (driver.inbuffer.data.length > MAX_HEADER_SIZE) {  // Check if we exceed the max header size
-                custom(2, "CLIENT", "header too large from %s:%s", ip, port);
+                log(Level.Verbose, "CLIENT", "header too large from %s:%s", ip, port);
                 driver.setHeaderTooLarge(response); stop(); continue;
               }
             } else {
               size_t limit  = (driver.header.indexOf("multipart/") >= 0) ? MAX_UPLOAD_SIZE : MAX_REQUEST_SIZE;
               if (driver.inbuffer.data.length > limit) {
-                custom(2, "CLIENT", "request too large from %s:%s", ip, port);
+                log(Level.Verbose, "request too large from %s:%s", ip, port);
                 driver.setPayloadTooLarge(response); stop(); continue;
               }
             }
-            if (!response.ready) {                            // If we're not ready to respond yet
-              // Parse the data and try to create a response (Could fail multiple times)
-              router.route(driver, request, response, maxtime);
-            }
+            // Parse the data and try to create a response (Could fail multiple times)
+            if (!response.ready) { router.route(driver, request, response, maxtime); }
           }
           if (response.ready && !response.completed) {      // We know what to respond, but haven't send all of it yet
-            //custom(1, "CLIENT", "sending: index=%d length=%d isRange=%s", response.index, response.length, response.isRange);
+            log(Level.Trace, "sending: index=%d length=%d isRange=%s", response.index, response.length, response.isRange);
             driver.send(response, driver.socket);           // Send the response, hit multiple times, send what you can and return
           }
           if (response.ready && response.completed) {       // We've completed the request, response cycle
-            //custom(1, "CLIENT", "completed: index=%d length=%d", response.index, response.length);
-            router.logRequest(this, request, response);     // Log the response to the request
+            req(this, request, response);
+            log(Level.Trace, "completed: index=%d length=%d", response.index, response.length);
             request.clearUploadFiles();                     // Clean uploaded files
             request.destroy();                              // Clear the request structure
             driver.inbuffer.destroy();                      // Clear the input buffer
@@ -75,27 +74,21 @@ class Client : Thread, ClientInterface {
             response.destroy();                             // Clear the response structure
           }
           if (lastmodified >= maxtime) { // Client are not allowed to be silent for more than maxtime
-            //custom(1, "CLIENT", "timeout: index=%d length=%d completed=%s", response.index, response.length, response.completed);
-            custom(2, "CLIENT", "inactivity: %s > %s", lastmodified, maxtime);
-            if (!response.ready && request !is Request.init) { // We have an unhandled request
-              driver.setTimedOut(response);
-              router.logRequest(this, request, response);     // Log the response to the request
-            }
+            log(Level.Trace, "timeout: index=%d length=%d completed=%s", response.index, response.length, response.completed);
+            log(Level.Trace, "inactivity: %s > %s", lastmodified, maxtime);
+            driver.setTimedOut(response);
+            req(this, request, response);
             stop(); continue;
           }
-          custom(3, "CLIENT", "connection %s:%s (%s msecs) %s", ip, port, starttime, to!string(driver.inbuffer.data));
+          log(Level.Trace, "Connection %s:%s (%s msecs) %s", ip, port, starttime, to!string(driver.inbuffer.data));
           Thread.sleep(dur!"msecs"(2));
         }
-      } catch(Exception e) { 
-        warning("Unknown Client Exception: %s", e);
-        stop();
-      } catch(Error e) {
-        warning("Unknown Client Error: %s", e);
-        stop();
-      }
-      custom(1, "CLIENT", "connection %s:%s (%s) closed after %d requests %s (%s msecs)", ip, port, (driver.isSecure() ? "SSL" : "HTTP"), 
-                                                                                          driver.requests, driver.senddata, starttime);
-      driver.destroy();                                               // Clear the response structure
+      } catch(Exception e) { log(Level.Verbose, "Unknown Client Exception: %s", e); stop();
+      } catch(Error e) { log(Level.Verbose, "Unknown Client Error: %s", e); stop(); }
+
+      log(Level.Verbose, "Connection %s:%s (%s) closed. %d requests %s (%s msecs)", ip, port, (driver.isSecure() ? "SSL" : "HTTP"), 
+                                                                                    driver.requests, driver.senddata, starttime);
+      driver.destroy();
     }
 
     // Is the client still running, if the socket was gone it's not otherwise check the terminated flag
@@ -106,7 +99,7 @@ class Client : Thread, ClientInterface {
 
     // Stop the client by setting the terminated flag
     final @property void stop() {
-      trace("connection %s:%s stop called", ip, port);
+      log(Level.Trace, "connection %s:%s stop called", ip, port);
       atomicStore(terminated, true);
     }
 
@@ -118,6 +111,13 @@ class Client : Thread, ClientInterface {
     final @property long port() const { return(driver.port()); } 
     // ip address of the client
     final @property string ip() const { return(driver.ip()); } 
+}
+
+void req(in ClientInterface cl, in Request rq, in Response rs) {
+  string uri;
+  try { uri = decodeComponent(rq.uri); } catch (Exception e) { uri = rq.uri; }
+  long bytes = rs.isRange ? (rs.rangeEnd - rs.rangeStart + 1) : rs.payload.length;
+  req(format("%d", rs.statuscode), "%s %s:%s %s%s %s %s", htmltime(), cl.ip, cl.port, rq.shorthost, uri.replace("%", "%%"), Msecs(rq.starttime), bytes);
 }
 
 // serve a 408 connection timed out page
@@ -140,8 +140,8 @@ void setPayloadTooLarge(ref DriverInterface driver, ref Response response) {
 }
 
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
-  auto router = new Router("./www/", Address.init, NORMAL);
+  tag(Level.Always, "FILE", "%s", __FILE__);
+  auto router = new Router("./www/", Address.init);
 
   router.runRequest("GET /test.pdf HTTP/1.1\nHost: localhost\nRange: bytes=0-65535\n\n");
   router.runRequest("GET /test.pdf HTTP/1.1\nHost: localhost\nRange: bytes=32517-\n\n");

--- a/danode/files.d
+++ b/danode/files.d
@@ -4,7 +4,7 @@ import danode.imports;
 import danode.statuscode : StatusCode;
 import danode.mimetypes : mime;
 import danode.payload : Payload, PayloadType, Message;
-import danode.log : custom, info, warning, trace, cverbose, DEBUG;
+import danode.log : log, error, Level;
 import danode.functions : isCGI;
 import danode.request : Request;
 import danode.response : Response, notModified;
@@ -23,7 +23,7 @@ class FileStream : Payload {
       this.payload = payload;
       if (payload.realfile) {
         try { handle = File(payload.filePath(), "rb"); }
-        catch (Exception e) { warning("FileStream: failed to open '%s': %s", payload.filePath(), e.msg); }
+        catch (Exception e) { log(Level.Verbose, "FileStream: failed to open '%s': %s", payload.filePath(), e.msg); }
       }
     }
 
@@ -44,7 +44,7 @@ class FileStream : Payload {
         char[] tmpbuf = new char[](r[1]);
         handle.seek(r[0]);
         return handle.rawRead!char(tmpbuf).dup;
-      } catch (Exception e) { warning("FileStream.bytes exception '%s': %s", payload.filePath(), e.msg); return []; }
+      } catch (Exception e) { log(Level.Verbose, "FileStream.bytes exception '%s': %s", payload.filePath(), e.msg); return []; }
     }
 }
 
@@ -72,10 +72,10 @@ class FilePayload : Payload {
     final bool needsupdate() {
       if (!isStaticFile()) return false; // CGI files are never buffered, since they are executed
       if (fileSize() > 0 && fileSize() < buffermaxsize) { //
-        if (!buffered) { trace("need to buffer file record: %s", path); return true; }
-        if (mtime > btime) { trace("re-buffer stale file record: %s", path); return true; }
+        if (!buffered) { log(Level.Trace, "need to buffer file record: %s", path); return true; }
+        if (mtime > btime) { log(Level.Trace, "re-buffer stale file record: %s", path); return true; }
       }else{
-        info("file %s does not fit into the buffer (%d)", path, buffermaxsize);
+        log(Level.Verbose, "file %s does not fit into the buffer (%d)", path, buffermaxsize);
       }
       return false;
     }
@@ -90,14 +90,12 @@ class FilePayload : Payload {
         auto f = File(path, "rb");
         f.rawRead(buf);
         f.close();
-      } catch (Exception e) { warning("exception during buffering '%s': %s", path, e.msg); return; }
+      } catch (Exception e) { log(Level.Verbose, "exception during buffering '%s': %s", path, e.msg); return; }
       try {
         encbuf = cast(char[])( compress(buf, 9) );
-      } catch (Exception e) {
-        warning("exception during compressing '%s': %s", path, e.msg);
-      }
+      } catch (Exception e) { log(Level.Verbose, "exception during compressing '%s': %s", path, e.msg); }
       btime = Clock.currTime();
-      trace("buffered %s: %d|%d bytes", path, fileSize(), encbuf.length);
+      log(Level.Trace, "buffered %s: %d|%d bytes", path, fileSize(), encbuf.length);
       buffered = true;
     } }
 
@@ -138,15 +136,15 @@ class FilePayload : Payload {
     /* Get bytes in a lockfree manner from the correct underlying buffer */
     final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 4096, bool isRange = false, long start = 0, long end = -1) { synchronized {
       if (!realfile) { return []; }
-      if (needsupdate) { buffer();  if (!buffered) { warning("FilePayload.bytes() failed to buffer '%s'", path); return([]); } }
+      if (needsupdate) { buffer();  if (!buffered) { log(Level.Verbose, "FilePayload.bytes() failed to buffer '%s'", path); return([]); } }
       auto r = rangeCalc(from, maxsize, isRange, start, end);
-      trace("bytes: isRange=%s start=%d end=%d from=%d offset=%d sz=%d", isRange, start, end, from, r[0], r[1]);
+      log(Level.Trace, "bytes: isRange=%s start=%d end=%d from=%d offset=%d sz=%d", isRange, start, end, from, r[0], r[1]);
       if(hasEncodedVersion && deflate) {
         if(r[0] < encbuf.length) return( encbuf[r[0] .. to!ptrdiff_t(min(r[0]+r[1], $))] );
       } else {
         if(r[0] < buf.length) return( buf[r[0] .. to!ptrdiff_t(min(r[0]+r[1], $))] );
       }
-      warning("FilePayload.bytes() called on unbuffered file '%s', this should not happen", path);
+      log(Level.Verbose, "FilePayload.bytes() called on unbuffered file '%s', this should not happen", path);
       return([]);
     } }
 }
@@ -161,11 +159,11 @@ class FilePayload : Payload {
 
 // Serve a static file from the disc, send encrypted when requested and available
 void serveStaticFile(ref Response response, in Request request, FileSystem fs) {
-  trace("serving a static file");
+  log(Level.Trace, "serving a static file");
   string localroot = fs.localroot(request.shorthost());
   FilePayload reqFile = fs.file(localroot, request.path);
   if (request.acceptsEncoding("deflate") && reqFile.hasEncodedVersion && !request.hasRange) {
-    info("will serve %s with deflate encoding", request.path);
+    log(Level.Verbose, "will serve %s with deflate encoding", request.path);
     reqFile.deflate = true;
     response.customheader("Content-Encoding","deflate");
   }
@@ -175,7 +173,7 @@ void serveStaticFile(ref Response response, in Request request, FileSystem fs) {
 
   if (!reqFile.deflate) response.customheader("Accept-Ranges", "bytes");
   if (request.ifModified >= response.payload.mtime()) {
-    trace("static file has not changed, sending notmodified");
+    log(Level.Trace, "static file has not changed, sending notmodified");
     response.notModified(response.payload.mimetype);
   }
   response.ready = true;
@@ -197,7 +195,7 @@ void serveRangeFile(ref Response response, in Request request, FilePayload reqFi
     response.rangeEnd = end;
     response.isRange = true;
     response.payload = new FileStream(reqFile);
-    trace("serveRangeFile: serving %d bytes", end - start + 1);
+    log(Level.Trace, "serveRangeFile: serving %d bytes", end - start + 1);
   }
   response.ready = true;
 }

--- a/danode/files.d
+++ b/danode/files.d
@@ -72,10 +72,10 @@ class FilePayload : Payload {
     final bool needsupdate() {
       if (!isStaticFile()) return false; // CGI files are never buffered, since they are executed
       if (fileSize() > 0 && fileSize() < buffermaxsize) { //
-        if (!buffered) { log(Level.Trace, "need to buffer file record: %s", path); return true; }
-        if (mtime > btime) { log(Level.Trace, "re-buffer stale file record: %s", path); return true; }
+        if (!buffered) { log(Level.Trace, "File: '%s' needs buffering", path); return true; }
+        if (mtime > btime) { log(Level.Trace, "File: '%s' stale record", path); return true; }
       }else{
-        log(Level.Verbose, "file %s does not fit into the buffer (%d)", path, buffermaxsize);
+        log(Level.Verbose, "File: '%s' exceeds buffer (%d > %d)", path, fileSize(), buffermaxsize);
       }
       return false;
     }
@@ -90,12 +90,12 @@ class FilePayload : Payload {
         auto f = File(path, "rb");
         f.rawRead(buf);
         f.close();
-      } catch (Exception e) { log(Level.Verbose, "exception during buffering '%s': %s", path, e.msg); return; }
+      } catch (Exception e) { error("Exception during buffering '%s': %s", path, e.msg); return; }
       try {
         encbuf = cast(char[])( compress(buf, 9) );
-      } catch (Exception e) { log(Level.Verbose, "exception during compressing '%s': %s", path, e.msg); }
+      } catch (Exception e) { error("Exception during compressing '%s': %s", path, e.msg); }
       btime = Clock.currTime();
-      log(Level.Trace, "buffered %s: %d|%d bytes", path, fileSize(), encbuf.length);
+      log(Level.Trace, "File: '%s' buffered %d|%d bytes", path, fileSize(), encbuf.length);
       buffered = true;
     } }
 

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -6,7 +6,7 @@ import danode.mimetypes : mime;
 import danode.payload : Payload, PayloadType;
 import danode.files : FilePayload, FileStream;
 import danode.functions : has, isCGI;
-import danode.log : custom, info, Log, warning, trace, cverbose, NOTSET, NORMAL, DEBUG;
+import danode.log : tag, log, error, Level;
 
 /* Domain name structure containing files in that domain
    Domains are loaded by the FileSystem from the -wwwRoot variable (set to www/ by default)
@@ -26,12 +26,10 @@ class FileSystem {
   private:
     string         root;
     Domain[string] domains;
-    Log            logger;
     size_t         maxsize;
 
   public:
-    this(Log logger, string root = "./www/", size_t maxsize = 1024 * 512){
-      this.logger   = logger;
+    this(string root = "./www/", size_t maxsize = 1024 * 512){
       this.root = buildNormalizedPath(absolutePath(root)).replace("\\", "/");
       if (!this.root.endsWith("/")) this.root ~= "/";
       this.maxsize  = maxsize;
@@ -54,7 +52,7 @@ class FileSystem {
         if (f.isFile()) {
           string shortname = replace(f.name[dname.length .. $], "\\", "/");
           if (shortname.endsWith(".in") || shortname.endsWith(".up")) continue;
-          custom(2, "SCAN", "file: %s -> %s", f.name, shortname);
+          log(Level.Trace, "file: %s -> %s", f.name, shortname);
           if (!domain.files.has(shortname)) {
             domain.files[shortname] = new FilePayload(f.name, maxsize);
             domain.entries++;
@@ -68,8 +66,8 @@ class FileSystem {
       // Remove files that no longer exist on disk
       foreach (k; domain.files.keys) { if (!exists(dname ~ k)) { domain.files.remove(k); } }
 
-      custom(1, "SCAN", "domain: %s, files %s|%s", dname, domain.buffered, domain.entries);
-      custom(1, "SCAN", "%s = size: %.2f/%.2f kB", dname, domain.buffersize / 1024.0, domain.size / 1024.0);
+      log(Level.Verbose, "domain: %s, files %s|%s", dname, domain.buffered, domain.entries);
+      log(Level.Verbose, "%s = size: %.2f/%.2f kB", dname, domain.buffersize / 1024.0, domain.size / 1024.0);
       return(domain);
     } }
 
@@ -79,11 +77,11 @@ class FileSystem {
     /* Get the FilePayload at path from the localroot, with update check on buffers */
     final FilePayload file(string localroot, string path){ synchronized {
       if (!(localroot in domains)) {
-        warning("file(): unknown domain '%s'", localroot);
+        log(Level.Verbose, "file(): unknown domain '%s'", localroot);
         return new FilePayload("", maxsize);
       }
       if (!domains[localroot].files.has(path) && exists(format("%s%s", localroot, path))) {
-        custom(1, "SCAN", "New file %s, rescanning index: %s", path, localroot);
+        log(Level.Verbose, "New file %s, rescanning index: %s", path, localroot);
         domains[localroot] = scan(localroot);
       }
       // File exists, buffer the individual file if modified after buffer date
@@ -91,7 +89,7 @@ class FileSystem {
         if (domains[localroot].files[path].needsupdate) domains[localroot].files[path].buffer();
         return(domains[localroot].files[path]);
       }
-      custom(0, "SCAN", "should not be here not in index, but exists %s, %s", path, localroot);
+      error("should not be here not in index, but exists %s, %s", path, localroot);
       return new FilePayload("", maxsize);
     } }
 
@@ -106,22 +104,21 @@ class FileSystem {
 
 /* Basic unit-tests should be extended */
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
-  Log logger = new Log(NORMAL);
-  FileSystem filesystem = new FileSystem(logger, "./www/");
-  custom(0, "TEST", "./www/localhost/dmd.d (6 bytes) = %s", filesystem.file(filesystem.localroot("localhost"), "/dmd.d").bytes(0,6));
-  custom(0, "TEST", "filesystem.localroot('localhost') = %s", filesystem.localroot("localhost"));
+  tag(Level.Always, "FILE", "%s", __FILE__);
+  FileSystem filesystem = new FileSystem("./www/");
+  tag(Level.Always, "TEST", "./www/localhost/dmd.d (6 bytes) = %s", filesystem.file(filesystem.localroot("localhost"), "/dmd.d").bytes(0,6));
+  tag(Level.Always, "TEST", "filesystem.localroot('localhost') = %s", filesystem.localroot("localhost"));
   Domain localhost = filesystem.scan("www/localhost");
-  custom(0, "TEST", "localhost.buffersize() = %s", localhost.buffersize());
-  custom(0, "TEST", "localhost.size() = %s", localhost.size());
+  tag(Level.Always, "TEST", "localhost.buffersize() = %s", localhost.buffersize());
+  tag(Level.Always, "TEST", "localhost.size() = %s", localhost.size());
   auto file = filesystem.file(filesystem.localroot("localhost"), "/dmd.d");
   auto stream = new FileStream(file);
-  custom(0, "TEST", "FileStream.bytes(0) = %s", stream.bytes(0, 6));
-  custom(0, "TEST", "file.statuscode() = %s", file.statuscode());
-  custom(0, "TEST", "file.mimetype() = %s", file.mimetype());
-  custom(0, "TEST", "file.mtime() = %s", file.mtime());
-  custom(0, "TEST", "file.ready() = %s", file.ready());
-  custom(0, "TEST", "file.type() = %s", file.type());
-  custom(0, "TEST", "file.content() = %s", file.content());
+  tag(Level.Always, "TEST", "FileStream.bytes(0) = %s", stream.bytes(0, 6));
+  tag(Level.Always, "TEST", "file.statuscode() = %s", file.statuscode());
+  tag(Level.Always, "TEST", "file.mimetype() = %s", file.mimetype());
+  tag(Level.Always, "TEST", "file.mtime() = %s", file.mtime());
+  tag(Level.Always, "TEST", "file.ready() = %s", file.ready());
+  tag(Level.Always, "TEST", "file.type() = %s", file.type());
+  tag(Level.Always, "TEST", "file.content() = %s", file.content());
 }
 

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -52,7 +52,7 @@ class FileSystem {
         if (f.isFile()) {
           string shortname = replace(f.name[dname.length .. $], "\\", "/");
           if (shortname.endsWith(".in") || shortname.endsWith(".up")) continue;
-          log(Level.Trace, "file: %s -> %s", f.name, shortname);
+          log(Level.Trace, "File: '%s' as '%s'", f.name, shortname);
           if (!domain.files.has(shortname)) {
             domain.files[shortname] = new FilePayload(f.name, maxsize);
             domain.entries++;
@@ -66,8 +66,8 @@ class FileSystem {
       // Remove files that no longer exist on disk
       foreach (k; domain.files.keys) { if (!exists(dname ~ k)) { domain.files.remove(k); } }
 
-      log(Level.Verbose, "domain: %s, files %s|%s", dname, domain.buffered, domain.entries);
-      log(Level.Verbose, "%s = size: %.2f/%.2f kB", dname, domain.buffersize / 1024.0, domain.size / 1024.0);
+      log(Level.Verbose, "Domain: '%s' files %s|%s", dname, domain.buffered, domain.entries);
+      log(Level.Verbose, "Domain: '%s' size %.2f/%.2f kB", dname, domain.buffersize / 1024.0, domain.size / 1024.0);
       return(domain);
     } }
 
@@ -77,11 +77,11 @@ class FileSystem {
     /* Get the FilePayload at path from the localroot, with update check on buffers */
     final FilePayload file(string localroot, string path){ synchronized {
       if (!(localroot in domains)) {
-        log(Level.Verbose, "file(): unknown domain '%s'", localroot);
+        log(Level.Verbose, "File: '%s' unknown domain '%s'", path, localroot);
         return new FilePayload("", maxsize);
       }
       if (!domains[localroot].files.has(path) && exists(format("%s%s", localroot, path))) {
-        log(Level.Verbose, "New file %s, rescanning index: %s", path, localroot);
+        log(Level.Verbose, "File: '%s' new, rescanning index: %s", path, localroot);
         domains[localroot] = scan(localroot);
       }
       // File exists, buffer the individual file if modified after buffer date
@@ -89,7 +89,7 @@ class FileSystem {
         if (domains[localroot].files[path].needsupdate) domains[localroot].files[path].buffer();
         return(domains[localroot].files[path]);
       }
-      error("should not be here not in index, but exists %s, %s", path, localroot);
+      error("Should not be here, %s not in index, but exists %s", path, localroot);
       return new FilePayload("", maxsize);
     } }
 

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -23,9 +23,7 @@ SysTime parseHtmlDate(const string datestr) {
     try {
       ts = SysTime(DateTime(to!int(m.captures[3]), monthToIndex(m.captures[2]), to!int(m.captures[1]),      // 21 Apr 2014
                             to!int(m.captures[4]), to!int(m.captures[5]), to!int(m.captures[6])), UTC());   // 20:20:13
-    } catch(Exception e) {
-       log(Level.Verbose, "parseHtmlDate exception, could not parse '%s'", datestr);
-    }
+    } catch(Exception e) { error("parseHtmlDate exception, could not parse '%s'", datestr); }
   }
   return(ts);
 }
@@ -34,9 +32,9 @@ pure string htmlEscape(string s) nothrow {
   return(s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&#39;"));
 }
 
-string resolve(string path){ return(buildNormalizedPath(absolutePath(path)).replace("\\", "/")); }
+pure string resolve(string path) { return(buildNormalizedPath(absolutePath(path)).replace("\\", "/")); }
 
-string resolveFolder(string path){
+string resolveFolder(string path) {
   path = path.resolve();
   path = (path.endsWith("/"))? path : path ~ "/";
   if (!exists(path)) mkdirRecurse(path);
@@ -92,13 +90,13 @@ string[string] parseQueryString(const string query) {
   return(*p);
 }
 
-void writeinfile(in string localpath, in string content) {
+void writeFile(in string localpath, in string content) {
   try {
     auto fp = File(localpath, "wb");
     fp.rawWrite(content);
     fp.close();
-    log(Level.Trace, "writeinfile: %d bytes to: %s", content.length, localpath);
-  } catch(Exception e) { error("writeinfile: I/O exception '%s'", e.msg); }
+    log(Level.Trace, "writeFile: %d bytes to: %s", content.length, localpath);
+  } catch(Exception e) { error("writeFile: I/O exception '%s'", e.msg); }
 }
 
 string htmltime(in SysTime d = Clock.currTime()) {

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -1,7 +1,8 @@
 module danode.functions;
 
 import danode.imports;
-import danode.log : error, warning, trace, custom;
+
+import danode.log : log, tag, error, Level;
 import danode.mimetypes : CGI_FILE, mime, UNSUPPORTED_FILE;
 
 immutable string[int] months; 
@@ -23,14 +24,23 @@ SysTime parseHtmlDate(const string datestr) {
       ts = SysTime(DateTime(to!int(m.captures[3]), monthToIndex(m.captures[2]), to!int(m.captures[1]),      // 21 Apr 2014
                             to!int(m.captures[4]), to!int(m.captures[5]), to!int(m.captures[6])), UTC());   // 20:20:13
     } catch(Exception e) {
-       warning("parseHtmlDate exception, could not parse '%s'", datestr);
+       log(Level.Verbose, "parseHtmlDate exception, could not parse '%s'", datestr);
     }
   }
   return(ts);
 }
 
-pure string htmlEscape(string s) {
+pure string htmlEscape(string s) nothrow {
   return(s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&#39;"));
+}
+
+string resolve(string path){ return(buildNormalizedPath(absolutePath(path)).replace("\\", "/")); }
+
+string resolveFolder(string path){
+  path = path.resolve();
+  path = (path.endsWith("/"))? path : path ~ "/";
+  if (!exists(path)) mkdirRecurse(path);
+  return(path);
 }
 
 // Returns null if path escapes root
@@ -40,7 +50,7 @@ string safePath(in string root, in string path) {
   string full = root ~ (path.startsWith("/") ? path : "/" ~ path);
   try {
     if (exists(full)) {
-      string resolved = buildNormalizedPath(absolutePath(full)).replace("\\", "/");
+      string resolved = full.resolve();
       string absroot  = root.endsWith("/") ? root : root ~ "/";
       if (resolved != absroot[0..$-1] && !resolved.startsWith(absroot)) return null;
     }
@@ -71,7 +81,7 @@ string[string] parseQueryString(const string query) {
       string key   = decodeComponent(i > 0 ? s[0 .. i]   : s);
       string value = decodeComponent(i > 0 ? s[i+1 .. $] : "");
       if (key.length > 0) params[key] = value;
-    } catch (Exception e) { warning("parseQueryString: failed to decode '%s'", param); }
+    } catch (Exception e) { error("parseQueryString: failed to decode '%s'", param); }
   }
   return params;
 }
@@ -87,7 +97,7 @@ void writeinfile(in string localpath, in string content) {
     auto fp = File(localpath, "wb");
     fp.rawWrite(content);
     fp.close();
-    trace("writeinfile: %d bytes to: %s", content.length, localpath);
+    log(Level.Trace, "writeinfile: %d bytes to: %s", content.length, localpath);
   } catch(Exception e) { error("writeinfile: I/O exception '%s'", e.msg); }
 }
 
@@ -168,16 +178,16 @@ int sISelect(SocketSet set, Socket socket, int timeout = 10) {
 }
 
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
-  custom(0, "TEST", "monthToIndex('Feb') = %s", monthToIndex("Feb"));
-  custom(0, "TEST", "htmltime() = %s", htmltime());
-  custom(0, "TEST", "isFILE('danode/functions.d') = %s", isFILE("danode/functions.d"));
-  custom(0, "TEST", "isDIR('danode') = %s", isDIR("danode"));
-  custom(0, "TEST", "isCGI('www/localhost/dmd.d') = %s", isCGI("www/localhost/dmd.d"));
-  custom(0, "TEST", "isAllowed('www/localhost/data.ill') = %s", isAllowed("www/localhost/data.ill"));
-  custom(0, "TEST", "isAllowed('www/localhost/index.html') = %s", isAllowed("www/localhost/index.html"));
-  custom(0, "TEST", "interpreter('www/localhost/dmd.d') = %s", interpreter("www/localhost/dmd.d"));
-  custom(0, "TEST", "interpreter('www/localhost/php.php') = %s", interpreter("www/localhost/php.php"));
-  custom(0, "TEST", "browseDir('www', 'localhost') = %s", browseDir("www", "www/localhost"));
+  tag(Level.Always, "FILE", "%s", __FILE__);
+  tag(Level.Always, "TEST", "monthToIndex('Feb') = %s", monthToIndex("Feb"));
+  tag(Level.Always, "TEST", "htmltime() = %s", htmltime());
+  tag(Level.Always, "TEST", "isFILE('danode/functions.d') = %s", isFILE("danode/functions.d"));
+  tag(Level.Always, "TEST", "isDIR('danode') = %s", isDIR("danode"));
+  tag(Level.Always, "TEST", "isCGI('www/localhost/dmd.d') = %s", isCGI("www/localhost/dmd.d"));
+  tag(Level.Always, "TEST", "isAllowed('www/localhost/data.ill') = %s", isAllowed("www/localhost/data.ill"));
+  tag(Level.Always, "TEST", "isAllowed('www/localhost/index.html') = %s", isAllowed("www/localhost/index.html"));
+  tag(Level.Always, "TEST", "interpreter('www/localhost/dmd.d') = %s", interpreter("www/localhost/dmd.d"));
+  tag(Level.Always, "TEST", "interpreter('www/localhost/php.php') = %s", interpreter("www/localhost/php.php"));
+  tag(Level.Always, "TEST", "browseDir('www', 'localhost') = %s", browseDir("www", "www/localhost"));
 }
 

--- a/danode/http.d
+++ b/danode/http.d
@@ -3,7 +3,7 @@ module danode.http;
 import danode.imports;
 import danode.interfaces : DriverInterface;
 import danode.response : Response;
-import danode.log : custom, warning, error;
+import danode.log : log, tag, error, Level;
 
 class HTTP : DriverInterface {
   public:
@@ -16,7 +16,7 @@ class HTTP : DriverInterface {
       } catch(Exception e) { error("unable to accept socket: %s", e.msg); return(false); }
       try {
         address = socket.remoteAddress();
-      } catch(Exception e) { warning("unable to resolve requesting origin: %s", e.msg); }
+      } catch(Exception e) { error("unable to resolve requesting origin: %s", e.msg); }
       return(true);
     }
 
@@ -28,7 +28,7 @@ class HTTP : DriverInterface {
       if ((received = socket.receive(tmpbuffer)) > 0) {
         inbuffer.put(tmpbuffer[0 .. received]); touch();
       }
-      if(received > 0) custom(3, "HTTP", "received %d bytes of data", received);
+      if(received > 0) log(Level.Trace, "received %d bytes of data", received);
       return(inbuffer.data.length);
     }
 
@@ -40,7 +40,7 @@ class HTTP : DriverInterface {
       writeSet.add(socket);
       if (Socket.select(null, writeSet, null, dur!"msecs"(0)) <= 0) return;
       ptrdiff_t send = socket.send(response.bytes(maxsize));
-      custom(1, "HTTP", "send result=%d index=%d length=%d", send, response.index, response.length);
+      log(Level.Verbose, "send result=%d index=%d length=%d", send, response.index, response.length);
       if (send > 0) {
         touch();
         response.index += send;
@@ -55,13 +55,13 @@ class HTTP : DriverInterface {
         if (socket !is null) { if (socket.isAlive()) { socket.shutdown(SocketShutdown.BOTH); }
           socket.close();
         }
-      } catch(Exception e) { warning("unable to close socket: %s", e.msg); }
+      } catch(Exception e) { error("unable to close socket: %s", e.msg); }
     }
 
     @nogc override bool isSecure() const nothrow { return(false); }
 }
 
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
+  tag(Level.Always, "FILE", "%s", __FILE__);
 }
 

--- a/danode/http.d
+++ b/danode/http.d
@@ -13,14 +13,14 @@ class HTTP : DriverInterface {
     override bool openConnection() {
       try {
         socket.blocking = blocking;
-      } catch(Exception e) { error("unable to accept socket: %s", e.msg); return(false); }
+      } catch(Exception e) { error("Unable to accept socket: %s", e.msg); return(false); }
       try {
         address = socket.remoteAddress();
-      } catch(Exception e) { error("unable to resolve requesting origin: %s", e.msg); }
+      } catch(Exception e) { error("Unable to resolve requesting origin: %s", e.msg); }
       return(true);
     }
 
-    override long getData(ref char[] buffer) { return(socket.receive(buffer)); }
+    override long receiveData(ref char[] buffer) { return(socket.receive(buffer)); }
 
     // Send upto maxsize bytes from the response to the client
     override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096) {
@@ -30,7 +30,7 @@ class HTTP : DriverInterface {
       writeSet.add(socket);
       if (Socket.select(null, writeSet, null, dur!"msecs"(0)) <= 0) return;
       ptrdiff_t send = socket.send(response.bytes(maxsize));
-      log(Level.Verbose, "send result=%d index=%d length=%d", send, response.index, response.length);
+      log(Level.Verbose, "Send result=%d index=%d length=%d", send, response.index, response.length);
       if (send > 0) {
         touch();
         response.index += send;

--- a/danode/http.d
+++ b/danode/http.d
@@ -20,17 +20,7 @@ class HTTP : DriverInterface {
       return(true);
     }
 
-    // Receive upto maxsize of bytes from the client into the input buffer
-    override ptrdiff_t receive(Socket socket, ptrdiff_t maxsize = 4096) {
-      if (!socketReady()) return(-1);
-      ptrdiff_t received;
-      char[] tmpbuffer = new char[](maxsize);
-      if ((received = socket.receive(tmpbuffer)) > 0) {
-        inbuffer.put(tmpbuffer[0 .. received]); touch();
-      }
-      if(received > 0) log(Level.Trace, "received %d bytes of data", received);
-      return(inbuffer.data.length);
-    }
+    override long getData(ref char[] buffer) { return(socket.receive(buffer)); }
 
     // Send upto maxsize bytes from the response to the client
     override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096) {
@@ -50,13 +40,7 @@ class HTTP : DriverInterface {
     }
 
     // Close the connection, by shutting down the socket
-    override void closeConnection() {
-      try {
-        if (socket !is null) { if (socket.isAlive()) { socket.shutdown(SocketShutdown.BOTH); }
-          socket.close();
-        }
-      } catch(Exception e) { error("unable to close socket: %s", e.msg); }
-    }
+    override void closeConnection() { closeSocket(); }
 
     @nogc override bool isSecure() const nothrow { return(false); }
 }

--- a/danode/https.d
+++ b/danode/https.d
@@ -78,24 +78,10 @@ version(SSL) {
         try {
           if (socketReady()) { SSL_shutdown(ssl); SSL_shutdown(ssl); }
         } catch(Exception e) { error("Exception during SSL shutdown: %s", e.msg); }
-        try {
-          if (socket !is null) { if (socket.isAlive()) { socket.shutdown(SocketShutdown.BOTH); }
-            socket.close();
-          }
-        } catch(Exception e) { error("Exception closing socket: %s", e.msg); }
+        closeSocket();
       }
 
-      // Receive upto maxsize of bytes from the client into the input buffer
-      override ptrdiff_t receive(Socket socket, ptrdiff_t maxsize = 4096){
-        if (!socketReady()) return -1;
-        ptrdiff_t received;
-        char[] tmpbuffer = new char[](maxsize);
-        if ((received = SSL_read(ssl, cast(void*) tmpbuffer, cast(int)maxsize)) > 0) {
-          inbuffer.put(tmpbuffer[0 .. received]); touch();
-        }
-        if(received > 0) log(Level.Trace, "received %d bytes of data", received);
-        return(inbuffer.data.length);
-      }
+      override long getData(ref char[] buffer) { return(SSL_read(ssl, cast(void*) buffer, cast(int)buffer.length)); }
 
       // Send upto maxsize bytes from the response to the client
       override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096){

--- a/danode/https.d
+++ b/danode/https.d
@@ -6,9 +6,8 @@ version(SSL) {
   import danode.imports;
   import danode.functions : Msecs;
   import danode.response : Response;
-  import danode.log : NORMAL, INFO, DEBUG;
+  import danode.log : log, error, Level;
   import danode.interfaces : DriverInterface;
-  import danode.log : custom, warning, error;
   import danode.ssl;
 
   immutable long HANDSHAKE_TIMEOUT = 5000;  // 5 seconds
@@ -23,7 +22,7 @@ version(SSL) {
 
       // Perform the SSL handshake
       bool performHandshake() {
-        custom(2, "HTTPS", "performing handshake");
+        log(Level.Trace, "performing handshake");
         int rA, rE;
         while (starttime < HANDSHAKE_TIMEOUT) {
           rA = SSL_accept(ssl);
@@ -35,37 +34,37 @@ version(SSL) {
           if (rE == SSL_ERROR_WANT_READ) Thread.sleep(5.msecs);
           if (rE == SSL_ERROR_WANT_WRITE) Thread.sleep(5.msecs);
         }
-        custom(2, "HTTPS", "handshake timed out after %d msecs", starttime);
+        log(Level.Trace, "handshake timed out after %d msecs", starttime);
         return(false);
       }
 
       // Open the connection by setting the socket to non blocking I/O, and registering the origin address
       override bool openConnection() {
-        custom(1, "HTTPS", "Opening HTTPS connection");
+        log(Level.Verbose, "Opening HTTPS connection");
         if (contexts.length > 0) {
-          custom(1, "HTTPS", "Number of SSL contexts: %d", contexts.length);
+          log(Level.Trace, "Number of SSL contexts: %d", contexts.length);
           try {
             if (!socket) { error("SSL was not given a valid socket (null)"); return(false); }
 
-            custom(1, "HTTPS", "set the socket the blocking mode");
+            log(Level.Trace, "set the socket the blocking mode");
             socket.blocking = blocking;
 
-            custom(1, "HTTPS", "creating a new ssl connection from context[0]");
+            log(Level.Trace, "creating a new ssl connection from context[0]");
             ssl = SSL_new(contexts[0].context);
 
-            custom(1, "HTTPS", "setting the socket handle I/O to SSL* object");
+            log(Level.Trace, "setting the socket handle I/O to SSL* object");
             ssl.SSL_set_fd(to!int(socket.handle()));
 
-            custom(1, "HTTPS", "SSL_set_accept_state to server mode");
+            log(Level.Trace, "SSL_set_accept_state to server mode");
             SSL_set_accept_state(ssl);
 
-            if (!performHandshake()) { custom(2, "ERROR", "couldn't handshake SSL connection"); return(false); }
+            if (!performHandshake()) { log(Level.Verbose, "couldn't handshake SSL connection"); return(false); }
           } catch (Exception e) { error("couldn't open SSL connection : %s", e.msg); return(false);
           }
           try {
             address = socket.remoteAddress();
-          } catch (Exception e) { warning("unable to resolve requesting origin: %s", e.msg); }
-          custom(1, "HTTPS", "HTTPS connection opened");
+          } catch (Exception e) { error("unable to resolve requesting origin: %s", e.msg); }
+          log(Level.Verbose, "HTTPS connection opened");
           return(true);
         }
         error("HTTPS driver failed: 'Server has no certificates loaded'");
@@ -78,12 +77,12 @@ version(SSL) {
       override void closeConnection() {
         try {
           if (socketReady()) { SSL_shutdown(ssl); SSL_shutdown(ssl); }
-        } catch(Exception e) { warning("Exception during SSL shutdown: %s", e.msg); }
+        } catch(Exception e) { error("Exception during SSL shutdown: %s", e.msg); }
         try {
           if (socket !is null) { if (socket.isAlive()) { socket.shutdown(SocketShutdown.BOTH); }
             socket.close();
           }
-        } catch(Exception e) { warning("Exception closing socket: %s", e.msg); }
+        } catch(Exception e) { error("Exception closing socket: %s", e.msg); }
       }
 
       // Receive upto maxsize of bytes from the client into the input buffer
@@ -94,7 +93,7 @@ version(SSL) {
         if ((received = SSL_read(ssl, cast(void*) tmpbuffer, cast(int)maxsize)) > 0) {
           inbuffer.put(tmpbuffer[0 .. received]); touch();
         }
-        if(received > 0) custom(3, "HTTPS", "received %d bytes of data", received);
+        if(received > 0) log(Level.Trace, "received %d bytes of data", received);
         return(inbuffer.data.length);
       }
 
@@ -105,7 +104,7 @@ version(SSL) {
         if (pending.length == 0) pending = response.bytes(maxsize).dup;
         if (pending.length == 0) return;
         ptrdiff_t send = SSL_write(ssl, cast(void*) pending.ptr, cast(int) pending.length);
-        custom(1, "HTTPS", "send result=%d index=%d length=%d", send, response.index, response.length);
+        log(Level.Verbose, "send result=%d index=%d length=%d", send, response.index, response.length);
         if (send > 0) {
           touch();
           response.index += send;

--- a/danode/https.d
+++ b/danode/https.d
@@ -6,7 +6,7 @@ version(SSL) {
   import danode.imports;
   import danode.functions : Msecs;
   import danode.response : Response;
-  import danode.log : log, error, Level;
+  import danode.log : tag, log, error, Level;
   import danode.interfaces : DriverInterface;
   import danode.ssl;
 
@@ -104,7 +104,7 @@ version(SSL) {
   }
 
   unittest {
-    custom(0, "FILE", "%s", __FILE__);
+    tag(Level.Always, "FILE", "%s", __FILE__);
   }
 }
 

--- a/danode/https.d
+++ b/danode/https.d
@@ -22,7 +22,7 @@ version(SSL) {
 
       // Perform the SSL handshake
       bool performHandshake() {
-        log(Level.Trace, "performing handshake");
+        log(Level.Trace, "Performing handshake");
         int rA, rE;
         while (starttime < HANDSHAKE_TIMEOUT) {
           rA = SSL_accept(ssl);
@@ -34,7 +34,7 @@ version(SSL) {
           if (rE == SSL_ERROR_WANT_READ) Thread.sleep(5.msecs);
           if (rE == SSL_ERROR_WANT_WRITE) Thread.sleep(5.msecs);
         }
-        log(Level.Trace, "handshake timed out after %d msecs", starttime);
+        log(Level.Trace, "Handshake timeout: %d msecs", starttime);
         return(false);
       }
 
@@ -46,24 +46,24 @@ version(SSL) {
           try {
             if (!socket) { error("SSL was not given a valid socket (null)"); return(false); }
 
-            log(Level.Trace, "set the socket the blocking mode");
+            log(Level.Trace, "Set the socket the blocking mode");
             socket.blocking = blocking;
 
-            log(Level.Trace, "creating a new ssl connection from context[0]");
+            log(Level.Trace, "Creating a new ssl connection from context[0]");
             ssl = SSL_new(contexts[0].context);
 
-            log(Level.Trace, "setting the socket handle I/O to SSL* object");
+            log(Level.Trace, "Setting the socket handle I/O to SSL* object");
             ssl.SSL_set_fd(to!int(socket.handle()));
 
             log(Level.Trace, "SSL_set_accept_state to server mode");
             SSL_set_accept_state(ssl);
 
             if (!performHandshake()) { log(Level.Verbose, "couldn't handshake SSL connection"); return(false); }
-          } catch (Exception e) { error("couldn't open SSL connection : %s", e.msg); return(false);
+          } catch (Exception e) { error("Couldn't open SSL connection : %s", e.msg); return(false);
           }
           try {
             address = socket.remoteAddress();
-          } catch (Exception e) { error("unable to resolve requesting origin: %s", e.msg); }
+          } catch (Exception e) { error("Unable to resolve requesting origin: %s", e.msg); }
           log(Level.Verbose, "HTTPS connection opened");
           return(true);
         }
@@ -81,7 +81,7 @@ version(SSL) {
         closeSocket();
       }
 
-      override long getData(ref char[] buffer) { return(SSL_read(ssl, cast(void*) buffer, cast(int)buffer.length)); }
+      override long receiveData(ref char[] buffer) { return(SSL_read(ssl, cast(void*) buffer, cast(int)buffer.length)); }
 
       // Send upto maxsize bytes from the response to the client
       override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096){
@@ -90,7 +90,7 @@ version(SSL) {
         if (pending.length == 0) pending = response.bytes(maxsize).dup;
         if (pending.length == 0) return;
         ptrdiff_t send = SSL_write(ssl, cast(void*) pending.ptr, cast(int) pending.length);
-        log(Level.Verbose, "send result=%d index=%d length=%d", send, response.index, response.length);
+        log(Level.Verbose, "Send result=%d index=%d length=%d", send, response.index, response.length);
         if (send > 0) {
           touch();
           response.index += send;

--- a/danode/interfaces.d
+++ b/danode/interfaces.d
@@ -45,12 +45,12 @@ abstract class DriverInterface {
       if (!socketReady()) return(-1);
       ptrdiff_t received;
       char[] tmpbuffer = new char[](maxsize);
-      if ((received = getData(tmpbuffer)) > 0) { inbuffer.put(tmpbuffer[0 .. received]); touch(); }
+      if ((received = receiveData(tmpbuffer)) > 0) { inbuffer.put(tmpbuffer[0 .. received]); touch(); }
       if(received > 0) log(Level.Trace, "Received %d bytes of data", received);
       return(inbuffer.data.length);
     }
 
-    long getData(ref char[] buffer);
+    long receiveData(ref char[] buffer);
     bool openConnection(); /// Open the connection
     void closeConnection(); /// Close the connection
     @nogc bool isSecure() const nothrow; /// Are we secure ?
@@ -99,16 +99,12 @@ abstract class DriverInterface {
 }
 
 class StringDriver : DriverInterface {
-    this(string input) {
-      super(null);
-      inbuffer ~= input;
-    }
+    this(string input) { super(null); inbuffer ~= input; }
     override bool openConnection() { return(true); }
     override void closeConnection() nothrow { }
     override bool isAlive() { return(true); }
     @nogc override bool isSecure() const nothrow { return(false); }
-    override long getData(ref char[] buffer) { buffer = inbuffer.data; return(buffer.length); }
-
+    override long receiveData(ref char[] buffer) { buffer = inbuffer.data; return(buffer.length); }
     override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096)  { 
       response.header();
       response.completed = true;

--- a/danode/interfaces.d
+++ b/danode/interfaces.d
@@ -33,8 +33,24 @@ abstract class DriverInterface {
     this(Socket socket, bool blocking = false) { this.socket = socket; this.blocking = blocking; systime = Clock.currTime(); touch(); }
     bool socketReady() { return socket !is null && socket.isAlive(); } /// Socket ready ?
     bool isAlive(){ return socket.isAlive(); }; /// Is the connection alive ?
-    final void touch() { modtime = Clock.currTime(); }
+    void touch() { modtime = Clock.currTime(); }
+    void closeSocket() {
+      try {
+        if (socket !is null) { if (socket.isAlive()) { socket.shutdown(SocketShutdown.BOTH); } socket.close(); }
+      } catch(Exception e) { error("Exception closing socket: %s", e.msg); }
+    }
 
+    // Receive upto maxsize of bytes from the client into the input buffer
+    ptrdiff_t receive(Socket socket, ptrdiff_t maxsize = 4096) {
+      if (!socketReady()) return(-1);
+      ptrdiff_t received;
+      char[] tmpbuffer = new char[](maxsize);
+      if ((received = getData(tmpbuffer)) > 0) { inbuffer.put(tmpbuffer[0 .. received]); touch(); }
+      if(received > 0) log(Level.Trace, "Received %d bytes of data", received);
+      return(inbuffer.data.length);
+    }
+
+    long getData(ref char[] buffer);
     bool openConnection(); /// Open the connection
     void closeConnection(); /// Close the connection
     @nogc bool isSecure() const nothrow; /// Are we secure ?
@@ -91,7 +107,8 @@ class StringDriver : DriverInterface {
     override void closeConnection() nothrow { }
     override bool isAlive() { return(true); }
     @nogc override bool isSecure() const nothrow { return(false); }
-    override ptrdiff_t receive(Socket socket, ptrdiff_t maxsize = 4096) { return(inbuffer.data.length); }
+    override long getData(ref char[] buffer) { buffer = inbuffer.data; return(buffer.length); }
+
     override void send(ref Response response, Socket socket, ptrdiff_t maxsize = 4096)  { 
       response.header();
       response.completed = true;

--- a/danode/interfaces.d
+++ b/danode/interfaces.d
@@ -3,7 +3,7 @@ module danode.interfaces;
 import danode.imports;
 import danode.functions : Msecs, bodystart, endofheader, fullheader;
 import danode.response : Response;
-import danode.log : NORMAL, INFO, DEBUG;
+import danode.log : log, error, Level;
 
 /* Client interface used by the server */
 interface ClientInterface {
@@ -29,7 +29,6 @@ abstract class DriverInterface {
     SysTime             modtime;             /// Time in ms since this process was last modified
     Address             address;             /// Private address field
     bool                blocking = false;    /// Blocking communication ?
-    int                 verbose = NORMAL;    /// Verbose level
 
     this(Socket socket, bool blocking = false) { this.socket = socket; this.blocking = blocking; systime = Clock.currTime(); touch(); }
     bool socketReady() { return socket !is null && socket.isAlive(); } /// Socket ready ?

--- a/danode/log.d
+++ b/danode/log.d
@@ -1,117 +1,48 @@
 module danode.log;
 
 import danode.imports;
-import danode.interfaces : ClientInterface;
-import danode.request : Request;
-import danode.response : Response;
-import danode.functions;
-import danode.statuscode : StatusCode;
 
-shared int cverbose;
+enum Level { Always = 0, Verbose = 1, Trace = 2 }
 
-immutable int NOTSET = -1, NORMAL = 0, INFO = 1, TRACE = 2, DEBUG = 3;
+shared int cv = 0;
 
-/* Verbose level control of stdout */
-void write(T)(const T fmt) { if(atomicLoad(cverbose) > 0) stdout.write(fmt); }
+private __gshared File serverFp;
+private __gshared File acmeFp;
+private __gshared File requestFp;
 
-/* Write an warning string to stdout */
-void warning(A...)(const string fmt, auto ref A args) { if(atomicLoad(cverbose) >= 0) writefln("[WARN]   " ~ fmt, args); }
-
-/* Informational level of debug to stdout */
-void info(A...)(const string fmt, auto ref A args) { if(atomicLoad(cverbose) >= 1) stdout.writefln("[INFO]   " ~ fmt, args); }
-
-/* Informational level of debug to stdout */
-void custom(A...)(const int lvl, const string pre, const string fmt, auto ref A args) {
-  if(atomicLoad(cverbose) >= lvl) { stdout.writefln("[%s]%s" ~ fmt, pre, " ".replicate(max(1, 7 - pre.length)), args); }
+shared static this() {
+  requestFp = stdout;
+  serverFp  = stdout;
+  acmeFp    = stdout;
 }
 
-/* Trace level debug to stdout */
-void trace(A...)(const string fmt, auto ref A args) { if(atomicLoad(cverbose) >= 2) stdout.writefln("[TRACE]  " ~ fmt, args); }
-
-/* Write an error string to stderr */
-void error(A...)(const string fmt, auto ref A args) { stderr.writefln("[ERROR]  " ~ fmt, args); }
-
-/* Abort with error code, default: -1 */
-void abort(in string s, int exitcode = -1){
-  error(s);
-  exit(exitcode);
+void initLogs(string dir = "logs/", int verbose) {
+  atomicStore(cv, verbose);
+  serverFp = File(dir ~ "server.log", "a");
+  requestFp = File(dir ~ "request.log", "a");
+  acmeFp = File(dir ~ "acme.log", "a");
 }
 
-/* Expect condition cond, otherwise abort the process */
-void expect(A...)(bool cond, string msg, auto ref A args) { if (!cond) abort(format(msg, args), -1); }
-
-struct Info {
-  long[StatusCode]      responses;
-  Appender!(long[])     starttimes;
-  Appender!(long[])     timings;
-  Appender!(bool[])     keepalives;
-  long[string]          useragents;
-  long[string]          ips;
-
-  void toString(scope void delegate(const(char)[]) sink, FormatSpec!char fmt) const {
-    sink(format("%s %d %.2f", responses, timings.data[($-1)], mean(timings.data)));
-  }
+private void logTo(A...)(ref File fp, string tag, const string fmt, auto ref A args) {
+  auto line = format("[%s] %s", tag, format(fmt, args));
+  fp.writeln(line); fp.flush();
+  if (atomicLoad(cv) >= 0) stdout.writeln(line);
 }
 
-class Log {
-  private:
-    File RequestLogFp;
-    File PerformanceLogFp;
-    Info[string] statistics;
+void log(A...)(Level lvl, const string fmt, auto ref A args) { if (atomicLoad(cv) >= lvl) logTo(serverFp, "SRV", fmt, args); }
+void acme(A...)(Level lvl, const string fmt, auto ref A args) { if (atomicLoad(cv) >= lvl) logTo(acmeFp, "ACME", fmt, args); }
+void tag(A...)(Level lvl, string tag, const string fmt, auto ref A args) { if (atomicLoad(cv) >= lvl) logTo(serverFp, tag, fmt, args); }
+void req(A...)(string tag, const string fmt, auto ref A args) { logTo(requestFp, tag, fmt, args); }
 
-  public:
-    this(int verbose = NORMAL, string requestLog = "request.log", string perfLog = "perf.log", bool overwrite = false) {
-      atomicStore(cverbose, verbose);
-
-      // Initialize the request log
-      if (exists(requestLog) && overwrite) {
-        warning("overwriting log: %s", requestLog); 
-        remove(requestLog);
-      }
-      RequestLogFp = File(requestLog, "a");
-
-      // Initialize the performance log
-      if (exists(perfLog) && overwrite) {
-        warning("overwriting log: %s", perfLog);
-        remove(perfLog);
-      }
-      PerformanceLogFp = File(perfLog, "a");
-    }
-
-    // Set verbose level of the application
-    @property @nogc int verbose(int verbose = NOTSET) const nothrow {
-      if (verbose != NOTSET) {
-        printf("[INFO]   changing verbose level from %d to %d\n", atomicLoad(cverbose), verbose);
-        atomicStore(cverbose, verbose);
-      }
-      return(atomicLoad(cverbose));
-    }
-
-    // Update the performance statistics
-    void updatePerformanceStatistics(in ClientInterface cl, in Request rq, in Response rs) {
-      string key = format("%s%s", rq.shorthost, rq.uripath);
-      if(!statistics.has(key)) statistics[key] = Info();    // Unknown key, create new Info statistics object
-      // Fill run-time statistics
-      statistics[key].responses[rs.statuscode]++;
-      statistics[key].starttimes.put(rq.starttime.toUnixTime());
-      statistics[key].timings.put(Msecs(rq.starttime));
-      statistics[key].keepalives.put(rs.keepalive);
-      statistics[key].ips[((rq.track)? cl.ip : "DNT")]++;
-      if (atomicLoad(cverbose) == TRACE) {
-        PerformanceLogFp.writefln("%s = [%s] %s", key, rs.statuscode, statistics[key]);
-        PerformanceLogFp.flush();
-      }
-    }
-
-    // Log the responses to the request
-    void logRequest(in ClientInterface cl, in Request rq, in Response rs) {
-      string uri;
-      try { uri = decodeComponent(rq.uri); } catch (Exception e) { uri = rq.uri; }
-      long bytes = rs.isRange ? (rs.rangeEnd - rs.rangeStart + 1) : rs.payload.length;
-      string s = format("[%d]    %s %s:%s %s%s %s %s", rs.statuscode, htmltime(), cl.ip, cl.port, rq.shorthost, uri.replace("%", "%%"), Msecs(rq.starttime), bytes);
-      RequestLogFp.writeln(s);
-      custom(-1, "REQ", s);
-      RequestLogFp.flush();
-    }
+void error(A...)(const string fmt, auto ref A args) {
+  stderr.writeln(format("[ERROR] " ~ fmt, args)); stderr.flush();
+  serverFp.logTo("ERROR", fmt, args);
 }
 
+void acmeError(A...)(const string fmt, auto ref A args) {
+  stderr.writeln(format("[ERROR] " ~ fmt, args)); stderr.flush();
+  acmeFp.logTo("ERROR", fmt, args);
+}
+
+void abort(in string s, int exitcode = -1) { error(s); exit(exitcode); }
+void expect(A...)(bool cond, string msg, auto ref A args) { if (!cond) abort(format(msg, args)); }

--- a/danode/log.d
+++ b/danode/log.d
@@ -16,7 +16,7 @@ shared static this() {
   acmeFp    = stdout;
 }
 
-void initLogs(string dir = "logs/", int verbose) {
+void initLogs(string dir = "logs/", int verbose = Level.Always) {
   atomicStore(cv, verbose);
   serverFp = File(dir ~ "server.log", "a");
   requestFp = File(dir ~ "request.log", "a");

--- a/danode/payload.d
+++ b/danode/payload.d
@@ -3,7 +3,7 @@ module danode.payload;
 import danode.imports;
 import danode.statuscode : StatusCode;
 import danode.mimetypes : UNSUPPORTED_FILE;
-import danode.log : custom, info, warning, trace;
+import danode.log : log, error, Level;
 
 enum PayloadType { Message, Script, File }
 enum HeaderType { None, FastCGI, HTTP10, HTTP11 }

--- a/danode/post.d
+++ b/danode/post.d
@@ -9,7 +9,7 @@ import danode.response : SERVERINFO, Response, redirect, create, setPayload;
 import danode.webconfig : WebConfig;
 import danode.mimetypes : mime;
 import danode.filesystem : FileSystem;
-import danode.functions : from, has, isCGI, isFILE, isDIR, writeinfile, parseQueryString;
+import danode.functions : from, has, isCGI, isFILE, isDIR, writeFile, parseQueryString;
 import danode.log : log, error, Level;
 
 immutable string      MPHEADER         = "multipart/form-data";                     /// Multipart header id
@@ -29,41 +29,41 @@ struct PostItem {
 // Parse the POST request data from the client, or waits (returning false) for more data 
 // when the entire request body is not yet available. POST data supplied in Multipart 
 // and X-form post formats are currently supported
-final bool parsePost (ref Request request, ref Response response, in FileSystem filesystem) {
+final bool parsePost(ref Request request, ref Response response, in FileSystem filesystem) {
   if (response.havepost || request.method != RequestMethod.POST) { return(response.havepost = true); }
 
   long expectedlength = to!long(from(request.headers, "Content-Length", "0"));
   string content = request.body;
   if (expectedlength == 0) {
-    log(Level.Trace, "Content-Length was not specified or 0: real length: %s", content.length);
+    log(Level.Trace, "Post: [T] Content-Length not specified (or 0), length: %s", content.length);
     return(response.havepost = true); // When we don't receive any post data it is meaningless to scan for any content
   } else if (expectedlength > MAX_REQUEST_SIZE) {
-    log(Level.Verbose, "Upload too large: %d bytes from %s", expectedlength, request.ip);
+    log(Level.Verbose, "Post: [W] Upload too large: %d bytes from %s", expectedlength, request.ip);
     response.setPayload(StatusCode.PayloadTooLarge, "413 - Payload Too Large\n", "text/plain");
     return(response.havepost = true);
   }
-  log(Level.Trace, "received %s of %s", content.length, expectedlength);
+  log(Level.Trace, "Post: [T] Received %s of %s", content.length, expectedlength);
   if(content.length < expectedlength) return(false);
 
   string contenttype = from(request.headers, "Content-Type");
   log(Level.Trace, "content type: %s", contenttype);
 
   if (contenttype.indexOf(XFORMHEADER) >= 0) {
-    log(Level.Verbose, "parsing %d bytes", expectedlength);
+    log(Level.Verbose, "XFORM: [I] parsing %d bytes", expectedlength);
     request.parseXform(content);
-    log(Level.Trace, "# of items: %s", request.postinfo.length);
+    log(Level.Verbose, "XFORM: [T] # of items: %s", request.postinfo.length);
   } else if (contenttype.indexOf(MPHEADER) >= 0) {
     auto parts = split(contenttype, "boundary=");
     if (parts.length < 2) return response.havepost = true;
     string mpid = parts[1];
-    log(Level.Verbose, "header: %s, parsing %d bytes", mpid, expectedlength);
+    log(Level.Verbose, "MPART: [I] header: %s, parsing %d bytes", mpid, expectedlength);
     request.parseMultipart(filesystem, content, mpid);
-    log(Level.Verbose, "# of items: %s", request.postinfo.length);
+    log(Level.Verbose, "MPART: [I] # of items: %s", request.postinfo.length);
   } else if (contenttype.indexOf(JSON) >= 0) {
-    log(Level.Verbose, "parsing %d bytes", expectedlength);
+    log(Level.Verbose, "JSON: [I] Parsing %d bytes", expectedlength);
     //request.postinfo["php://input"] = PostItem(PostType.File, "stdin", "php://input", content, JSON, content.length);
   } else {
-    error("unsupported POST content type: %s [%s] -> %s", contenttype, expectedlength, content);
+    error("parsePost: Unsupported POST content type: %s [%s] -> %s", contenttype, expectedlength, content);
     request.parseXform(content);
   }
   response.havepost = true;
@@ -94,7 +94,9 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
   int[string] keys;
   foreach (part; chomp(content).split(mpid)) {
     string[] elem = strip(part).split("\r\n");
-    if (elem.length < 2 || elem[0] == "--") { log(Level.Verbose, "ID element: %s", elem.length > 0 ? elem[0] : ""); continue; }
+    if (elem.length < 2 || elem[0] == "--") { 
+      log(Level.Verbose, "MPART: [I] ID element: %s", elem.length > 0 ? elem[0] : ""); continue; 
+    }
 
     string[] mphdr = elem[0].split("; ");
     if (mphdr.length < 2) continue;
@@ -109,10 +111,10 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
       request.postinfo[key] = PostItem(PostType.Input, key, "", join(elem[bodyLine .. ($-1)]));
     } else if (mphdr.length >= 3) {
       string fname = extractQuoted(elem[0], "filename");
-      log(Level.Verbose, "found on key %s file %s", key, fname);
+      log(Level.Verbose, "MPART: [I] found on key %s file %s", key, fname);
       bool isarraykey = key.length > 2 && key[($-2) .. $] == "[]";
       keys[key] = keys.get(key, -1) + 1;
-      log(Level.Verbose, "found on key %s #%d file %s", key, keys[key], fname);
+      log(Level.Verbose, "MPART: [I] found on key %s #%d file %s", key, keys[key], fname);
       if (fname != "") {
         string fkey      = isarraykey ? key ~ to!string(keys[key]) : key;
         string skey      = isarraykey ? key[0 .. $-2] : key;
@@ -121,8 +123,8 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
         auto mimeParts   = split(elem[bodyLine-1], ": ");
         string fileMime  = mimeParts.length >= 2 ? mimeParts[1] : "application/octet-stream";
         request.postinfo[fkey] = PostItem(PostType.File, skey, fname, localpath, fileMime, mpcontent.length);
-        writeinfile(localpath, mpcontent);
-        log(Level.Verbose, "wrote %d bytes to file %s", mpcontent.length, localpath);
+        localpath.writeFile(mpcontent);
+        log(Level.Verbose, "MPART: [I] Wrote %d bytes to file %s", mpcontent.length, localpath);
       } else { request.postinfo[key] = PostItem(PostType.Input, key, ""); }
     }
   }
@@ -160,8 +162,8 @@ final void serverAPI(in FileSystem filesystem, in WebConfig config, in Request r
     if(p.type == PostType.File)   content.put(format("F=%s=%s=%s=%s\n", p.name, p.filename, p.mime, p.value));
   }
 
-  string filename = request.inputfile(filesystem);
-  log(Level.Trace, "[IN %s]\n%s[/IN %s]", filename, content.data, filename);
-  writeinfile(filename, content.data);
+  string fIn = request.inputfile(filesystem);
+  log(Level.Trace, "API: [T] [IN %s]\n%s[/IN %s]", fIn, content.data, fIn);
+  fIn.writeFile(content.data);
 }
 

--- a/danode/post.d
+++ b/danode/post.d
@@ -10,7 +10,7 @@ import danode.webconfig : WebConfig;
 import danode.mimetypes : mime;
 import danode.filesystem : FileSystem;
 import danode.functions : from, has, isCGI, isFILE, isDIR, writeinfile, parseQueryString;
-import danode.log : info, custom, trace, warning;
+import danode.log : log, error, Level;
 
 immutable string      MPHEADER         = "multipart/form-data";                     /// Multipart header id
 immutable string      XFORMHEADER      = "application/x-www-form-urlencoded";       /// X-form header id
@@ -35,35 +35,35 @@ final bool parsePost (ref Request request, ref Response response, in FileSystem 
   long expectedlength = to!long(from(request.headers, "Content-Length", "0"));
   string content = request.body;
   if (expectedlength == 0) {
-    custom(2, "POST", "Content-Length was not specified or 0: real length: %s", content.length);
+    log(Level.Trace, "Content-Length was not specified or 0: real length: %s", content.length);
     return(response.havepost = true); // When we don't receive any post data it is meaningless to scan for any content
   } else if (expectedlength > MAX_REQUEST_SIZE) {
-    warning("Upload too large: %d bytes from %s", expectedlength, request.ip);
+    log(Level.Verbose, "Upload too large: %d bytes from %s", expectedlength, request.ip);
     response.setPayload(StatusCode.PayloadTooLarge, "413 - Payload Too Large\n", "text/plain");
     return(response.havepost = true);
   }
-  custom(2, "POST", "received %s of %s", content.length, expectedlength);
+  log(Level.Trace, "received %s of %s", content.length, expectedlength);
   if(content.length < expectedlength) return(false);
 
   string contenttype = from(request.headers, "Content-Type");
-  custom(2, "POST", "content type: %s", contenttype);
+  log(Level.Trace, "content type: %s", contenttype);
 
   if (contenttype.indexOf(XFORMHEADER) >= 0) {
-    custom(0, "XFORM", "parsing %d bytes", expectedlength);
+    log(Level.Verbose, "parsing %d bytes", expectedlength);
     request.parseXform(content);
-    custom(1, "XFORM", "# of items: %s", request.postinfo.length);
+    log(Level.Trace, "# of items: %s", request.postinfo.length);
   } else if (contenttype.indexOf(MPHEADER) >= 0) {
     auto parts = split(contenttype, "boundary=");
     if (parts.length < 2) return response.havepost = true;
     string mpid = parts[1];
-    custom(1, "MPART", "header: %s, parsing %d bytes", mpid, expectedlength);
+    log(Level.Verbose, "header: %s, parsing %d bytes", mpid, expectedlength);
     request.parseMultipart(filesystem, content, mpid);
-    custom(1, "MPART", "# of items: %s", request.postinfo.length);
+    log(Level.Verbose, "# of items: %s", request.postinfo.length);
   } else if (contenttype.indexOf(JSON) >= 0) {
-    custom(0, "JSONP", "parsing %d bytes", expectedlength);
+    log(Level.Verbose, "parsing %d bytes", expectedlength);
     //request.postinfo["php://input"] = PostItem(PostType.File, "stdin", "php://input", content, JSON, content.length);
   } else {
-    warning("unsupported POST content type: %s [%s] -> %s", contenttype, expectedlength, content);
+    error("unsupported POST content type: %s [%s] -> %s", contenttype, expectedlength, content);
     request.parseXform(content);
   }
   response.havepost = true;
@@ -84,7 +84,7 @@ pure string extractQuoted(string s, string key) nothrow {
   return j > i ? s[i .. j] : "";
 }
 
-pure ptrdiff_t findBodyLine(in string[] lines) nothrow {
+@nogc pure ptrdiff_t findBodyLine(in string[] lines) nothrow {
   foreach (i, line; lines) { if (strip(line).length == 0) return i + 1; }
   return -1;
 }
@@ -94,7 +94,7 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
   int[string] keys;
   foreach (part; chomp(content).split(mpid)) {
     string[] elem = strip(part).split("\r\n");
-    if (elem.length < 2 || elem[0] == "--") { custom(1, "MPART", "ID element: %s", elem.length > 0 ? elem[0] : ""); continue; }
+    if (elem.length < 2 || elem[0] == "--") { log(Level.Verbose, "ID element: %s", elem.length > 0 ? elem[0] : ""); continue; }
 
     string[] mphdr = elem[0].split("; ");
     if (mphdr.length < 2) continue;
@@ -109,10 +109,10 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
       request.postinfo[key] = PostItem(PostType.Input, key, "", join(elem[bodyLine .. ($-1)]));
     } else if (mphdr.length >= 3) {
       string fname = extractQuoted(elem[0], "filename");
-      custom(1, "MPART", "found on key %s file %s", key, fname);
+      log(Level.Verbose, "found on key %s file %s", key, fname);
       bool isarraykey = key.length > 2 && key[($-2) .. $] == "[]";
       keys[key] = keys.get(key, -1) + 1;
-      custom(1, "MPART", "found on key %s #%d file %s", key, keys[key], fname);
+      log(Level.Verbose, "found on key %s #%d file %s", key, keys[key], fname);
       if (fname != "") {
         string fkey      = isarraykey ? key ~ to!string(keys[key]) : key;
         string skey      = isarraykey ? key[0 .. $-2] : key;
@@ -122,7 +122,7 @@ final void parseMultipart(ref Request request, in FileSystem filesystem, const s
         string fileMime  = mimeParts.length >= 2 ? mimeParts[1] : "application/octet-stream";
         request.postinfo[fkey] = PostItem(PostType.File, skey, fname, localpath, fileMime, mpcontent.length);
         writeinfile(localpath, mpcontent);
-        custom(1, "MPART", "wrote %d bytes to file %s", mpcontent.length, localpath);
+        log(Level.Verbose, "wrote %d bytes to file %s", mpcontent.length, localpath);
       } else { request.postinfo[key] = PostItem(PostType.Input, key, ""); }
     }
   }
@@ -141,7 +141,7 @@ final void serverAPI(in FileSystem filesystem, in WebConfig config, in Request r
   try{
     content.put(format("S=SERVER_NAME=%s\n", (response.address)? response.address.toHostNameString() : "localhost"));
   }catch(Exception e){
-    warning("Exception while trying to call: toHostNameString()");
+    error("Exception while trying to call: toHostNameString()");
     content.put("S=SERVER_NAME=localhost\n");
   }
   content.put(format("S=SERVER_ADDR=%s\n", (response.address)? response.address.toAddrString() : "127.0.0.1"));
@@ -161,7 +161,7 @@ final void serverAPI(in FileSystem filesystem, in WebConfig config, in Request r
   }
 
   string filename = request.inputfile(filesystem);
-  trace("[IN %s]\n%s[/IN %s]", filename, content.data, filename);
+  log(Level.Trace, "[IN %s]\n%s[/IN %s]", filename, content.data, filename);
   writeinfile(filename, content.data);
 }
 

--- a/danode/process.d
+++ b/danode/process.d
@@ -4,10 +4,6 @@ import danode.imports;
 import danode.functions : Msecs;
 import danode.log : log, tag, error, Level;
 
-version(Posix) {
-  import core.sys.posix.fcntl : fcntl, F_SETFL, O_NONBLOCK;
-}
-
 immutable size_t MAX_CGI_OUTPUT = 1024 * 1024 * 10; // 10MB script output limit
 
 struct WaitResult {
@@ -18,12 +14,14 @@ struct WaitResult {
 /* Set a filestream to nonblocking mode, if not Posix, use winbase.h */
 bool nonblocking(ref File file) {
   version(Posix) {
+    import core.sys.posix.fcntl : fcntl, F_SETFL, O_NONBLOCK;
+
     return(fcntl(fileno(file.getFP()), F_SETFL, O_NONBLOCK) != -1); 
   }else{
     import core.sys.windows.winbase;
+
     auto x = PIPE_NOWAIT;
-    auto res = SetNamedPipeHandleState(file.windowsHandle(), &x, null, null);
-    return(res != 0);
+    return(SetNamedPipeHandleState(file.windowsHandle(), &x, null, null) != 0);
   }
 }
 
@@ -77,47 +75,31 @@ class Process : Thread {
 
      // Query Output/Errors from 'from' to the end, if the outbuffer contains any output this will be served
      // from is checked to be in-range of the outbuffer/errbuffer, if not an empty array is returned
-    final @property const(char)[] output(ptrdiff_t from) const { 
-      synchronized {
-        if (outbuffer.data.length > 0 && from >= 0 && from <= outbuffer.data.length) {
-          return outbuffer.data[from .. $];
-        }
-        if (from >= 0 && from <= errbuffer.data.length) {
-          return errbuffer.data[from .. $]; 
-        }
-        return [];
-      }
-    }
+    final @property const(char)[] output(ptrdiff_t from) const { synchronized {
+      if (outbuffer.data.length > 0 && from >= 0 && from <= outbuffer.data.length) { return outbuffer.data[from .. $]; }
+      if (from >= 0 && from <= errbuffer.data.length) { return errbuffer.data[from .. $]; }
+      return [];
+    } }
 
     // Runtime of the thread in mseconds
-    final @property long time() const {
-      synchronized { return(Msecs(starttime)); }
-    }
+    final @property long time() const { synchronized { return(Msecs(starttime)); } }
 
     // Last time the process was modified (e.g. data on stdout/stderr)
-    final @property long lastmodified() const {
-      synchronized { return(Msecs(modified)); }
-    }
+    final @property long lastmodified() const { synchronized { return(Msecs(modified)); } }
 
     // Is the external process still running ?
-    final @property bool running() const { 
-      synchronized { return(!process.terminated); }
-    }
+    final @property bool running() const { synchronized { return(!process.terminated); } }
 
     // Did our internal thread finish processing the external process, etc ?
-    final @property bool finished() const { 
-      synchronized { return(this.completed); }
-    }
+    final @property bool finished() const { synchronized { return(this.completed); } }
 
     // Returns the 'flattened' exit status of the external process 
     // ( -1 = non-0 exit code, 0 = succes, 1 = still running )
-    final @property int status() const { 
-      synchronized { 
-        if (running) return 1;
-        if (process.status == 0) return 0;
-        return -1;
-      }
-    }
+    final @property int status() const { synchronized {
+      if (running) return 1;
+      if (process.status == 0) return 0;
+      return -1;
+    } }
 
     // Length of output, if the outbuffer contains any data, the outbuffer will be prefered (errors are silenced)
     final @property long length() const { synchronized { 
@@ -141,7 +123,7 @@ class Process : Thread {
           }
         }
       } catch (Exception e) { error("Exception during readpipe command: %s", e); file.close();
-      } catch(Error e) { error("Error during readpipe command: %s", e); file.close();
+      } catch (Error e) { error("Error during readpipe command: %s", e); file.close();
       }
     }
 

--- a/danode/process.d
+++ b/danode/process.d
@@ -2,7 +2,8 @@ module danode.process;
 
 import danode.imports;
 import danode.functions : Msecs;
-import danode.log : custom, warning, trace;
+import danode.log : log, tag, error, Level;
+
 version(Posix) {
   import core.sys.posix.fcntl : fcntl, F_SETFL, O_NONBLOCK;
 }
@@ -139,8 +140,8 @@ class Process : Thread {
             break;
           }
         }
-      } catch (Exception e) { warning("Exception during readpipe command: %s", e); file.close();
-      } catch(Error e) { warning("Error during readpipe command: %s", e); file.close();
+      } catch (Exception e) { error("Exception during readpipe command: %s", e); file.close();
+      } catch(Error e) { error("Error during readpipe command: %s", e); file.close();
       }
     }
 
@@ -157,22 +158,22 @@ class Process : Thread {
     final void run() {
       try {
         if( !exists(inputfile) ) {
-          warning("no input path: %s", inputfile);
+          log(Level.Verbose, "no input path: %s", inputfile);
           this.process.terminated = true;
           this.completed = true;
           return;
         }
         fStdIn = File(inputfile, "r");
         pStdOut = pipe(); pStdErr = pipe();
-        custom(1, "PROC", "command: %s < %s", command, inputfile);
+        log(Level.Verbose, "command: %s < %s", command, inputfile);
         import std.process : Config;
         auto cpid = spawnProcess(command, fStdIn, pStdOut.writeEnd, pStdErr.writeEnd, environ, Config.none, environ.get("PWD", "."));
 
         fStdOut = pStdOut.readEnd;
-        if(!nonblocking(fStdOut) && fStdOut.isOpen()) custom(2, "WARN", "unable to create nonblocking stdout pipe for command");
+        if(!nonblocking(fStdOut) && fStdOut.isOpen()) log(Level.Trace, "unable to create nonblocking stdout pipe for command");
 
         fStdErr = pStdErr.readEnd;
-        if(!nonblocking(fStdErr) && fStdErr.isOpen()) custom(2, "WARN", "unable to create nonblocking error pipe for command");
+        if(!nonblocking(fStdErr) && fStdErr.isOpen()) log(Level.Trace, "unable to create nonblocking error pipe for command");
 
         while (running && lastmodified < maxtime) {
           drainPipes();
@@ -180,33 +181,33 @@ class Process : Thread {
           Thread.sleep(msecs(1));
         }
         if (!process.terminated) {
-          warning("command: %s < %s did not finish in time [%s msecs]", command, inputfile, time()); 
+          log(Level.Verbose, "command: %s < %s did not finish in time [%s msecs]", command, inputfile, time()); 
           killProcess(cpid, 9);
           process = WaitResult(true, wait(cpid));
         }
-        trace("command finished %d after %s msecs", status(), time());
+        log(Level.Verbose, "command finished %d after %s msecs", status(), time());
         drainPipes();
 
-        trace("Output %d & %d processed after %s msecs", outbuffer.data.length, errbuffer.data.length, time());
-        if (errbuffer.data.length > 0) custom(1, "PROC", "stderr: %s", errbuffer.data);
+        log(Level.Trace, "Output %d & %d processed after %s msecs", outbuffer.data.length, errbuffer.data.length, time());
+        if (errbuffer.data.length > 0) log(Level.Verbose, "stderr: %s", errbuffer.data);
 
         // Close the file handles
         fStdIn.close(); fStdOut.close(); fStdErr.close();
 
-        trace("removing process input file %s ? %s", inputfile, removeInput);
+        log(Level.Trace, "removing process input file %s ? %s", inputfile, removeInput);
         if(removeInput) remove(inputfile);
-      } catch(Exception e) { warning("process.d, exception: '%s'", e.msg); }
+      } catch(Exception e) { error("process.d, exception: '%s'", e.msg); }
       this.completed = true;
     }
 }
 
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
+  tag(Level.Always, "FILE", "%s", __FILE__);
   auto p = new Process(["rdmd", "www/localhost/dmd.d"], "test/dmd.in", null, false);
   p.start();
   while(!p.finished){ Thread.sleep(msecs(5)); }
-  custom(0, "TEST", "status of output: %s", p.status());
-  custom(0, "TEST", "length of output: %s", p.length());
-  custom(0, "TEST", "time of output: %s", p.time());
+  tag(Level.Always, "TEST", "status of output: %s", p.status());
+  tag(Level.Always, "TEST", "length of output: %s", p.length());
+  tag(Level.Always, "TEST", "time of output: %s", p.time());
 }
 

--- a/danode/process.d
+++ b/danode/process.d
@@ -4,10 +4,6 @@ import danode.imports;
 import danode.functions : Msecs;
 import danode.log : log, tag, error, Level;
 
-version(Posix) {
-  import core.sys.posix.fcntl : fcntl, F_SETFL, O_NONBLOCK;
-}
-
 immutable size_t MAX_CGI_OUTPUT = 1024 * 1024 * 10; // 10MB script output limit
 
 struct WaitResult {
@@ -18,12 +14,14 @@ struct WaitResult {
 /* Set a filestream to nonblocking mode, if not Posix, use winbase.h */
 bool nonblocking(ref File file) {
   version(Posix) {
+    import core.sys.posix.fcntl : fcntl, F_SETFL, O_NONBLOCK;
+
     return(fcntl(fileno(file.getFP()), F_SETFL, O_NONBLOCK) != -1); 
   }else{
     import core.sys.windows.winbase;
+
     auto x = PIPE_NOWAIT;
-    auto res = SetNamedPipeHandleState(file.windowsHandle(), &x, null, null);
-    return(res != 0);
+    return(SetNamedPipeHandleState(file.windowsHandle(), &x, null, null) != 0);
   }
 }
 
@@ -43,7 +41,6 @@ class Process : Thread {
     string[]          command;              /// Command to execute
     string            inputfile;            /// Path of input file
     string[string]    environ;
-    bool              completed = false;
     bool              removeInput = true;
 
     File              fStdIn;               /// Input file stream
@@ -55,8 +52,10 @@ class Process : Thread {
 
     WaitResult        process;              /// Process try/wait results
     SysTime           starttime;            /// Time in ms since this process came alive
-    SysTime           modified;             /// Time in ms since this process was modified
-    long              maxtime;              /// Maximum time in ms before we kill the process
+
+    shared long       modified;             /// Time in ms since this process was modified
+    shared bool       completed = false;
+    shared long       maxtime;              /// Maximum time in ms before we kill the process
 
     Appender!(char[])  outbuffer;           /// Output appender buffer
     Appender!(char[])  errbuffer;           /// Error appender buffer
@@ -69,7 +68,7 @@ class Process : Thread {
       this.removeInput = removeInput;
       this.maxtime = maxtime;
       this.starttime = Clock.currTime();
-      this.modified = Clock.currTime();
+      atomicStore(modified, Clock.currTime().toUnixTime());
       this.outbuffer = appender!(char[])();
       this.errbuffer = appender!(char[])();
       super(&run);
@@ -78,52 +77,40 @@ class Process : Thread {
      // Query Output/Errors from 'from' to the end, if the outbuffer contains any output this will be served
      // from is checked to be in-range of the outbuffer/errbuffer, if not an empty array is returned
     final @property const(char)[] output(ptrdiff_t from) const { 
-      synchronized {
-        if (outbuffer.data.length > 0 && from >= 0 && from <= outbuffer.data.length) {
-          return outbuffer.data[from .. $];
-        }
-        if (from >= 0 && from <= errbuffer.data.length) {
-          return errbuffer.data[from .. $]; 
-        }
-        return [];
+      if (outbuffer.data.length > 0 && from >= 0 && from <= outbuffer.data.length) {
+        return outbuffer.data[from .. $];
       }
+      if (from >= 0 && from <= errbuffer.data.length) {
+        return errbuffer.data[from .. $]; 
+      }
+      return [];
     }
 
     // Runtime of the thread in mseconds
-    final @property long time() const {
-      synchronized { return(Msecs(starttime)); }
-    }
+    final @property long time() const { return(Msecs(starttime)); }
 
     // Last time the process was modified (e.g. data on stdout/stderr)
-    final @property long lastmodified() const {
-      synchronized { return(Msecs(modified)); }
-    }
+    final @property long lastmodified() const { return Msecs(SysTime(atomicLoad(modified))); }
 
     // Is the external process still running ?
-    final @property bool running() const { 
-      synchronized { return(!process.terminated); }
-    }
+    final @property bool running() const { return(!process.terminated); }
 
     // Did our internal thread finish processing the external process, etc ?
-    final @property bool finished() const { 
-      synchronized { return(this.completed); }
-    }
+    final @property bool finished() const { return atomicLoad(completed); }
 
     // Returns the 'flattened' exit status of the external process 
     // ( -1 = non-0 exit code, 0 = succes, 1 = still running )
     final @property int status() const { 
-      synchronized { 
-        if (running) return 1;
-        if (process.status == 0) return 0;
-        return -1;
-      }
+      if (running) return 1;
+      if (process.status == 0) return 0;
+      return -1;
     }
 
     // Length of output, if the outbuffer contains any data, the outbuffer will be prefered (errors are silenced)
-    final @property long length() const { synchronized { 
+    final @property long length() const {
       if (outbuffer.data.length > 0) { return(outbuffer.data.length); }
       return errbuffer.data.length; 
-    } }
+    }
 
     // Read a character from a filestream and append it to buffer
     void readpipe(ref File file, ref Appender!(char[]) buffer) {
@@ -134,7 +121,7 @@ class Process : Thread {
         while (lastmodified < maxtime && buffer.data.length < MAX_CGI_OUTPUT) {
           n = fread(tmp.ptr, 1, tmp.sizeof, fp);
           if (n > 0) {
-            modified = Clock.currTime();
+            atomicStore(modified, Clock.currTime().toUnixTime());
             buffer.put(tmp[0 .. n]);
           } else {
             break;
@@ -148,7 +135,7 @@ class Process : Thread {
     // Drain both stdout & stderr
     void drainPipes() { readpipe(fStdOut, outbuffer); readpipe(fStdErr, errbuffer); }
 
-    @property void notifyovertime() { maxtime = -1; }
+    @property void notifyovertime() { atomicStore(maxtime, -1L); }
 
     // Execute the process
     // check the input path, and create a pipe:StdIn to the input file
@@ -197,7 +184,7 @@ class Process : Thread {
         log(Level.Trace, "removing process input file %s ? %s", inputfile, removeInput);
         if(removeInput) remove(inputfile);
       } catch(Exception e) { error("process.d, exception: '%s'", e.msg); }
-      this.completed = true;
+      atomicStore(completed, true);
     }
 }
 

--- a/danode/process.d
+++ b/danode/process.d
@@ -4,6 +4,10 @@ import danode.imports;
 import danode.functions : Msecs;
 import danode.log : log, tag, error, Level;
 
+version(Posix) {
+  import core.sys.posix.fcntl : fcntl, F_SETFL, O_NONBLOCK;
+}
+
 immutable size_t MAX_CGI_OUTPUT = 1024 * 1024 * 10; // 10MB script output limit
 
 struct WaitResult {
@@ -14,14 +18,12 @@ struct WaitResult {
 /* Set a filestream to nonblocking mode, if not Posix, use winbase.h */
 bool nonblocking(ref File file) {
   version(Posix) {
-    import core.sys.posix.fcntl : fcntl, F_SETFL, O_NONBLOCK;
-
     return(fcntl(fileno(file.getFP()), F_SETFL, O_NONBLOCK) != -1); 
   }else{
     import core.sys.windows.winbase;
-
     auto x = PIPE_NOWAIT;
-    return(SetNamedPipeHandleState(file.windowsHandle(), &x, null, null) != 0);
+    auto res = SetNamedPipeHandleState(file.windowsHandle(), &x, null, null);
+    return(res != 0);
   }
 }
 
@@ -41,6 +43,7 @@ class Process : Thread {
     string[]          command;              /// Command to execute
     string            inputfile;            /// Path of input file
     string[string]    environ;
+    bool              completed = false;
     bool              removeInput = true;
 
     File              fStdIn;               /// Input file stream
@@ -52,10 +55,8 @@ class Process : Thread {
 
     WaitResult        process;              /// Process try/wait results
     SysTime           starttime;            /// Time in ms since this process came alive
-
-    shared long       modified;             /// Time in ms since this process was modified
-    shared bool       completed = false;
-    shared long       maxtime;              /// Maximum time in ms before we kill the process
+    SysTime           modified;             /// Time in ms since this process was modified
+    long              maxtime;              /// Maximum time in ms before we kill the process
 
     Appender!(char[])  outbuffer;           /// Output appender buffer
     Appender!(char[])  errbuffer;           /// Error appender buffer
@@ -68,7 +69,7 @@ class Process : Thread {
       this.removeInput = removeInput;
       this.maxtime = maxtime;
       this.starttime = Clock.currTime();
-      atomicStore(modified, Clock.currTime().toUnixTime());
+      this.modified = Clock.currTime();
       this.outbuffer = appender!(char[])();
       this.errbuffer = appender!(char[])();
       super(&run);
@@ -77,40 +78,52 @@ class Process : Thread {
      // Query Output/Errors from 'from' to the end, if the outbuffer contains any output this will be served
      // from is checked to be in-range of the outbuffer/errbuffer, if not an empty array is returned
     final @property const(char)[] output(ptrdiff_t from) const { 
-      if (outbuffer.data.length > 0 && from >= 0 && from <= outbuffer.data.length) {
-        return outbuffer.data[from .. $];
+      synchronized {
+        if (outbuffer.data.length > 0 && from >= 0 && from <= outbuffer.data.length) {
+          return outbuffer.data[from .. $];
+        }
+        if (from >= 0 && from <= errbuffer.data.length) {
+          return errbuffer.data[from .. $]; 
+        }
+        return [];
       }
-      if (from >= 0 && from <= errbuffer.data.length) {
-        return errbuffer.data[from .. $]; 
-      }
-      return [];
     }
 
     // Runtime of the thread in mseconds
-    final @property long time() const { return(Msecs(starttime)); }
+    final @property long time() const {
+      synchronized { return(Msecs(starttime)); }
+    }
 
     // Last time the process was modified (e.g. data on stdout/stderr)
-    final @property long lastmodified() const { return Msecs(SysTime(atomicLoad(modified))); }
+    final @property long lastmodified() const {
+      synchronized { return(Msecs(modified)); }
+    }
 
     // Is the external process still running ?
-    final @property bool running() const { return(!process.terminated); }
+    final @property bool running() const { 
+      synchronized { return(!process.terminated); }
+    }
 
     // Did our internal thread finish processing the external process, etc ?
-    final @property bool finished() const { return atomicLoad(completed); }
+    final @property bool finished() const { 
+      synchronized { return(this.completed); }
+    }
 
     // Returns the 'flattened' exit status of the external process 
     // ( -1 = non-0 exit code, 0 = succes, 1 = still running )
     final @property int status() const { 
-      if (running) return 1;
-      if (process.status == 0) return 0;
-      return -1;
+      synchronized { 
+        if (running) return 1;
+        if (process.status == 0) return 0;
+        return -1;
+      }
     }
 
     // Length of output, if the outbuffer contains any data, the outbuffer will be prefered (errors are silenced)
-    final @property long length() const {
+    final @property long length() const { synchronized { 
       if (outbuffer.data.length > 0) { return(outbuffer.data.length); }
       return errbuffer.data.length; 
-    }
+    } }
 
     // Read a character from a filestream and append it to buffer
     void readpipe(ref File file, ref Appender!(char[]) buffer) {
@@ -121,7 +134,7 @@ class Process : Thread {
         while (lastmodified < maxtime && buffer.data.length < MAX_CGI_OUTPUT) {
           n = fread(tmp.ptr, 1, tmp.sizeof, fp);
           if (n > 0) {
-            atomicStore(modified, Clock.currTime().toUnixTime());
+            modified = Clock.currTime();
             buffer.put(tmp[0 .. n]);
           } else {
             break;
@@ -135,7 +148,7 @@ class Process : Thread {
     // Drain both stdout & stderr
     void drainPipes() { readpipe(fStdOut, outbuffer); readpipe(fStdErr, errbuffer); }
 
-    @property void notifyovertime() { atomicStore(maxtime, -1L); }
+    @property void notifyovertime() { maxtime = -1; }
 
     // Execute the process
     // check the input path, and create a pipe:StdIn to the input file
@@ -184,7 +197,7 @@ class Process : Thread {
         log(Level.Trace, "removing process input file %s ? %s", inputfile, removeInput);
         if(removeInput) remove(inputfile);
       } catch(Exception e) { error("process.d, exception: '%s'", e.msg); }
-      atomicStore(completed, true);
+      this.completed = true;
     }
 }
 

--- a/danode/request.d
+++ b/danode/request.d
@@ -6,7 +6,7 @@ import danode.interfaces : ClientInterface, DriverInterface;
 import danode.functions : interpreter, from, parseHtmlDate, parseQueryString;
 import danode.webconfig : WebConfig;
 import danode.post : PostItem, PostType;
-import danode.log : custom, info, trace, warning;
+import danode.log : log, tag, error, Level;
 
 // The Request-Method indicates which method is to be performed on the specified resource
 enum RequestMethod : string {
@@ -15,16 +15,12 @@ enum RequestMethod : string {
 }
 
 // The HTTP-Version indicates which protocol version is requested to obtain the specified resource
-enum HTTPVersion : string {
-  v09 = "HTTP/0.9", v10 = "HTTP/1.0", v11 = "HTTP/1.1", v20 = "HTTP/2", v30 = "HTTP/3"
-}
+enum HTTPVersion : string { v09 = "HTTP/0.9", v10 = "HTTP/1.0", v11 = "HTTP/1.1", v20 = "HTTP/2", v30 = "HTTP/3" }
 
 // Parse the HTTP-Version, throw an error if it cannot be parsed
-pure HTTPVersion parseHTTPVersion(const string line) {
-  foreach (immutable v; EnumMembers!HTTPVersion) {
-    if (v == line) return(v);
-  }
-  throw new Exception(format("invalid HTTP-Version requested: %s", line));
+@nogc pure HTTPVersion parseHTTPVersion(const string line) nothrow {
+  foreach (immutable v; EnumMembers!HTTPVersion) { if (v == line) return(v); }
+  return(HTTPVersion.v09);
 }
 
 // Parse the Request-Line: "method uri protocol"
@@ -65,8 +61,8 @@ struct Request {
     this.maxtime = maxtime;
     this.id = md5UUID(format("%s:%d-%s", driver.ip, driver.port, starttime));
     this.isValid = this.parseHeader(driver.header);
-    info("request: %s to %s from %s:%d - %s", method, uri, this.ip, this.port, this.id);
-    trace("request header: %s", driver.header);
+    log(Level.Verbose, "request: %s to %s from %s:%d - %s", method, uri, this.ip, this.port, this.id);
+    log(Level.Trace, "request header: %s", driver.header);
   }
 
   // Parse the HTTP request header (method, uri, protocol) as well as the supplemental headers
@@ -80,12 +76,9 @@ struct Request {
           if (parts.length > 1) this.headers[strip(parts[0])] = strip(join(parts[1 .. $], ":"));
         }
       }
-    } catch (Exception e) {
-      warning("parseHeader exception: %s", e.msg);
-      return(false);
-    }
-    trace("headers received: %s", this.headers);
-    trace("parseHeader %s %s %s, nParams: %d", this.method, this.uri, this.protocol, this.headers.length);
+    } catch (Exception e) { error("parseHeader exception: %s", e.msg); return(false); }
+    log(Level.Trace, "headers received: %s", this.headers);
+    log(Level.Trace, "parseHeader %s %s %s, nParams: %d", this.method, this.uri, this.protocol, this.headers.length);
     return(true);
   }
 
@@ -102,23 +95,19 @@ struct Request {
     return [start, end];
   }
 
-  final @property bool hasRange() const { return headers.from("Range").startsWith("bytes="); }
+  final @property @nogc bool hasRange() const nothrow { return headers.from("Range").startsWith("bytes="); }
 
   // The Host header requested in the request
-  final @property string host() const { 
+  final @property @nogc string host() const nothrow { 
     ptrdiff_t i = headers.from("Host").indexOf(":");
-    if (i > 0) {
-      return(headers.from("Host")[0 .. i]);
-    }
+    if (i > 0) { return(headers.from("Host")[0 .. i]); }
     return(headers.from("Host")); 
   }
 
   // The Port from the Host header in the request
   final @property ushort serverport() const {
     ptrdiff_t i = headers.from("Host").indexOf(":");
-    if (i > 0) { 
-      return( to!ushort(headers.from("Host")[(i+1) .. $]));
-    }
+    if (i > 0) { return( to!ushort(headers.from("Host")[(i+1) .. $])); }
     return(isSecure ? to!ushort(443) : to!ushort(80)); // return the default ports
   }
 
@@ -145,20 +134,20 @@ struct Request {
   }
 
   // decoded path component of url (post-rewrite)
-  final @property string path() const { ptrdiff_t i = url.indexOf("?"); if(i > 0){ return(url[0 .. i]); }else{ return(url); } }
+  final @property @nogc string path() const nothrow { ptrdiff_t i = url.indexOf("?"); if(i > 0){ return(url[0 .. i]); }else{ return(url); } }
 
   // query string component of uri (pre-rewrite)
-  final @property string query() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[i .. $]); }else{ return("?"); } }
+  final @property @nogc string query() const nothrow { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[i .. $]); }else{ return("?"); } }
 
   // path component of uri (pre-rewrite, used for canonical redirects)
-  final @property string uripath() const { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[0 .. i]); }else{ return(uri); } }
-  final @property bool keepalive() const { return(icmp(headers.from("Connection"), "keep-alive") == 0); }
+  final @property @nogc string uripath() const nothrow { ptrdiff_t i = uri.indexOf("?"); if(i > 0){ return(uri[0 .. i]); }else{ return(uri); } }
+  final @property @nogc bool keepalive() const nothrow { return(icmp(headers.from("Connection"), "keep-alive") == 0); }
   final @property SysTime ifModified() const { return(parseHtmlDate(headers.from("If-Modified-Since"))); }
-  final @property bool acceptsEncoding(string encoding = "deflate") const { return(headers.from("Accept-Encoding").canFind(encoding)); }
-  final @property bool track() const { return(  headers.from("DNT","0") == "0"); }
-  final @property string cookies() const { return(headers.from("Cookie")); }
-  final @property string useragent() const { return(headers.from("User-Agent", "Unknown")); }
-  final string shorthost() const { return host.startsWith("www.") ? host[4 .. $] : host; }
+  final @property @nogc bool acceptsEncoding(string encoding = "deflate") const nothrow { return(headers.from("Accept-Encoding").canFind(encoding)); }
+  final @property @nogc bool track() const nothrow { return(  headers.from("DNT","0") == "0"); }
+  final @property @nogc string cookies() const nothrow { return(headers.from("Cookie")); }
+  final @property @nogc string useragent() const nothrow { return(headers.from("User-Agent", "Unknown")); }
+  final @nogc string shorthost() const nothrow { return host.startsWith("www.") ? host[4 .. $] : host; }
   final string[] command(string localpath) const {
     import std.path : dirName;
     string interp = localpath.interpreter();
@@ -197,12 +186,12 @@ struct Request {
   // Clear all files uploaded by the user after the Request is done
   final void clearUploadFiles() const {
     foreach(f; postfiles) { if(exists(f)) {
-      trace("removing uploaded file at %s", f); 
+      log(Level.Verbose, "Removing uploaded file at %s", f); 
       remove(f);
     } }
   }
 }
 
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
+  tag(Level.Always, "FILE", "%s", __FILE__);
 }

--- a/danode/response.d
+++ b/danode/response.d
@@ -9,7 +9,7 @@ import danode.request : Request;
 import danode.mimetypes : UNSUPPORTED_FILE;
 import danode.files : FileStream, FilePayload;
 import danode.payload : Payload, PayloadType, HeaderType, Message;
-import danode.log;
+import danode.log : tag, log, Level;
 import danode.webconfig;
 import danode.filesystem : FileSystem;
 import danode.post : serverAPI;
@@ -45,7 +45,7 @@ struct Response {
       CGI script = to!CGI(payload);
       string scriptheader = script.fullHeader();
       auto status = script.statuscode();
-      custom(1, "INFO", "script '%s', status (%s)", script.command, status);
+      log(Level.Verbose, "script '%s', status (%s)", script.command, status);
       connection = script.getHeader("Connection", "No Request");
       long clength = script.getHeader("Content-Length", -1); // Is the content length provided ?
       foreach (line; scriptheader.split("\n")) {
@@ -63,15 +63,15 @@ struct Response {
         return(hdr.data);
       }
       if (connection != "No Request" && clength > -1) {
-        custom(0, "KEEP", "script '%s' in keepalive mode connection '%s' (%s, %d)", script.command, connection, script.headerType(), clength);
+        log(Level.Verbose, "script '%s' in keepalive mode connection '%s' (%s, %d)", script.command, connection, script.headerType(), clength);
         hdr.put(scriptheader);
         return(hdr.data); // The script can communicate
       }
       if (connection != "Close") {
-        custom(1, "WARN", "script '%s', failed - headerType: %s, Content-Length: %d, connection: '%s', headerLength: %d, header: [%s]", 
+        log(Level.Verbose, "script '%s', failed - headerType: %s, Content-Length: %d, connection: '%s', headerLength: %d, header: [%s]", 
                script.command, script.headerType(), clength, connection, scriptheader.length, scriptheader);
       }else{
-        custom(1, "INFO", "script '%s', header generation (%s, %d)", script.command, script.headerType(), clength);
+        log(Level.Verbose, "script '%s', header generation (%s, %d)", script.command, script.headerType(), clength);
       }
       connection = "Close";
     }
@@ -103,7 +103,7 @@ struct Response {
     if (isRange) return StatusCode.PartialContent;
     return payload.statuscode;
   }
-  @property final bool keepalive() const { return(icmp(connection, "keep-alive") == 0); }
+  @property @nogc final bool keepalive() const nothrow { return(icmp(connection, "keep-alive") == 0); }
   @property final long length() {
     if (isRange) return header.length + (rangeEnd - rangeStart + 1);
     return header.length + payload.length;
@@ -140,7 +140,7 @@ bool setPayload(ref Response response, StatusCode code, string msg = "", in stri
 
 // send a redirect permanently response
 void redirect(ref Response response, in Request request, in string fqdn, bool isSecure = false) {
-  trace("redirecting request to %s", fqdn);
+  log(Level.Trace, "redirecting request to %s", fqdn);
   response.setPayload(StatusCode.MovedPermanently);
   response.customheader("Location", format("http%s://%s%s%s", isSecure? "s": "", fqdn, request.path, request.query));
   response.connection = "Close";
@@ -158,13 +158,13 @@ void domainNotFound(ref Response response) {
 
 // serve a the output of an external script 
 void serveCGI(ref Response response, in Request request, in WebConfig config, in FileSystem fs, bool removeInput = true) {
-  trace("requested a cgi file, execution allowed");
+  log(Level.Trace, "requested a cgi file, execution allowed");
   string localroot = fs.localroot(request.shorthost());
   string localpath = config.localpath(localroot, request.path);
   if (!response.routed) { // Store POST data (could fail multiple times)
-    trace("writing server variables");
+    log(Level.Trace, "writing server variables");
     fs.serverAPI(config, request, response);
-    trace("creating CGI payload");
+    log(Level.Trace, "creating CGI payload");
     response.payload = new CGI(request.command(localpath), request.inputfile(fs), request.environ(localpath), removeInput, request.maxtime-5);
     response.ready = true;
   }
@@ -172,7 +172,7 @@ void serveCGI(ref Response response, in Request request, in WebConfig config, in
 
 // serve a directory browsing request, via a message
 void serveDirectory(ref Response response, ref Request request, in WebConfig config, in FileSystem fs) {
-  trace("sending browse directory");
+  log(Level.Trace, "Sending browse directory");
   string localroot = fs.localroot(request.shorthost());
   string localpath = config.localpath(localroot, request.path);
   response.setPayload(StatusCode.Ok, browseDir(localroot, localpath), "text/html");
@@ -194,6 +194,6 @@ void notFound(ref Response response) {
 }
 
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
+  tag(Level.Always, "FILE", "%s", __FILE__);
 }
 

--- a/danode/response.d
+++ b/danode/response.d
@@ -45,7 +45,7 @@ struct Response {
       CGI script = to!CGI(payload);
       string scriptheader = script.fullHeader();
       auto status = script.statuscode();
-      log(Level.Verbose, "script '%s', status (%s)", script.command, status);
+      log(Level.Verbose, "Script '%s', status (%s)", script.command, status);
       connection = script.getHeader("Connection", "No Request");
       long clength = script.getHeader("Content-Length", -1); // Is the content length provided ?
       foreach (line; scriptheader.split("\n")) {
@@ -63,15 +63,15 @@ struct Response {
         return(hdr.data);
       }
       if (connection != "No Request" && clength > -1) {
-        log(Level.Verbose, "script '%s' in keepalive mode connection '%s' (%s, %d)", script.command, connection, script.headerType(), clength);
+        log(Level.Verbose, "Script '%s' in keepalive mode connection '%s' (%s, %d)", script.command, connection, script.headerType(), clength);
         hdr.put(scriptheader);
         return(hdr.data); // The script can communicate
       }
       if (connection != "Close") {
-        log(Level.Verbose, "script '%s', failed - headerType: %s, Content-Length: %d, connection: '%s', headerLength: %d, header: [%s]", 
+        log(Level.Verbose, "Script '%s', failed - headerType: %s, Content-Length: %d, connection: '%s', headerLength: %d, header: [%s]", 
                script.command, script.headerType(), clength, connection, scriptheader.length, scriptheader);
       }else{
-        log(Level.Verbose, "script '%s', header generation (%s, %d)", script.command, script.headerType(), clength);
+        log(Level.Verbose, "Script '%s', header generation (%s, %d)", script.command, script.headerType(), clength);
       }
       connection = "Close";
     }
@@ -140,7 +140,7 @@ bool setPayload(ref Response response, StatusCode code, string msg = "", in stri
 
 // send a redirect permanently response
 void redirect(ref Response response, in Request request, in string fqdn, bool isSecure = false) {
-  log(Level.Trace, "redirecting request to %s", fqdn);
+  log(Level.Trace, "Redirecting request to %s", fqdn);
   response.setPayload(StatusCode.MovedPermanently);
   response.customheader("Location", format("http%s://%s%s%s", isSecure? "s": "", fqdn, request.path, request.query));
   response.connection = "Close";
@@ -158,13 +158,13 @@ void domainNotFound(ref Response response) {
 
 // serve a the output of an external script 
 void serveCGI(ref Response response, in Request request, in WebConfig config, in FileSystem fs, bool removeInput = true) {
-  log(Level.Trace, "requested a cgi file, execution allowed");
+  log(Level.Trace, "Requested a cgi file, execution allowed");
   string localroot = fs.localroot(request.shorthost());
   string localpath = config.localpath(localroot, request.path);
   if (!response.routed) { // Store POST data (could fail multiple times)
-    log(Level.Trace, "writing server variables");
+    log(Level.Trace, "Writing server variables");
     fs.serverAPI(config, request, response);
-    log(Level.Trace, "creating CGI payload");
+    log(Level.Trace, "Creating CGI payload");
     response.payload = new CGI(request.command(localpath), request.inputfile(fs), request.environ(localpath), removeInput, request.maxtime-5);
     response.ready = true;
   }

--- a/danode/router.d
+++ b/danode/router.d
@@ -12,7 +12,7 @@ import danode.webconfig : WebConfig;
 import danode.functions : from, has, isCGI, isFILE, isDIR, isAllowed, safePath;
 import danode.filesystem : FileSystem;
 import danode.post : parsePost;
-import danode.log : custom, trace, info, Log, NOTSET, NORMAL;
+import danode.log : log, tag, error, Level;
 
 version(SSL) {
   import danode.ssl : hasCertificate;
@@ -21,21 +21,13 @@ version(SSL) {
 class Router {
   private:
     FileSystem filesystem;
-    Log logger;
     WebConfig config;
     Address address;
 
   public:
-    this(string wwwRoot = "./www/", Address address = Address.init, int verbose = NORMAL){
-      this.logger = new Log(verbose);
+    this(string wwwRoot = "./www/", Address address = Address.init){
       this.address = address;
-      this.filesystem = new FileSystem(logger, wwwRoot);
-    }
-
-    // Update the performance statistics and log the finished request
-    void logRequest(in ClientInterface client, in Request request, in Response response) {
-      logger.updatePerformanceStatistics(client, request, response);
-      logger.logRequest(client, request, response);
+      this.filesystem = new FileSystem(wwwRoot);
     }
 
     // Parse the header of a request, or receive additional post data when the user is uploading
@@ -60,8 +52,8 @@ class Router {
       if (!request.isValid) return(response.badRequest());
 
       string localroot = filesystem.localroot(request.shorthost());
-      trace("%s:%s %s client (%s)", request.ip, request.port, (finalrewrite? "redirecting" : "routing"), request.id);
-      trace("shorthost -> localroot: %s -> %s", request.shorthost(), localroot);
+      log(Level.Trace, "%s:%s %s client (%s)", request.ip, request.port, (finalrewrite? "redirecting" : "routing"), request.id);
+      log(Level.Trace, "shorthost -> localroot: %s -> %s", request.shorthost(), localroot);
       if (request.shorthost() == "" || !exists(localroot)) return(response.domainNotFound());
 
       version(SSL) { if (serveACMEChallenge(request, response)) return; }
@@ -76,32 +68,31 @@ class Router {
       bool pathIsFILE  = pathExists && localpath.isFILE();
       bool pathIsDIR   = pathExists && localpath.isDIR();
       bool pathAllowed = localpath.isAllowed();
-      trace("safePath result: '%s', isFILE: %s, isAllowed: %s, isCGI: %s", localpath, pathIsFILE, pathAllowed, pathIsCGI);
-
-      trace("configfile at: %s%s", localroot, "/web.config");
-      trace("request.host: %s, fqdn: %s", request.host, fqdn);
-      trace("localpath: %s, exists ? %s", localpath, pathExists);
+      log(Level.Trace, "safePath result: '%s', isFILE: %s, isAllowed: %s, isCGI: %s", localpath, pathIsFILE, pathAllowed, pathIsCGI);
+      log(Level.Trace, "configfile at: %s%s", localroot, "/web.config");
+      log(Level.Trace, "request.host: %s, fqdn: %s", request.host, fqdn);
+      log(Level.Trace, "localpath: %s, exists ? %s", localpath, pathExists);
 
       version (SSL) {
         bool hasCert = hasCertificate(fqdn);
         if (request.isSecure != hasCert || request.host != fqdn) {
-          trace("SSL redirect %s != %s for %s to fqdn: %s", request.isSecure, hasCert, request.host, fqdn);
+          log(Level.Trace, "SSL redirect %s != %s for %s to fqdn: %s", request.isSecure, hasCert, request.host, fqdn);
           return(response.redirect(request, fqdn, hasCert));
         }
       } else { if (request.host != fqdn) { return(response.redirect(request, fqdn, false)); } }
 
       if (pathExists) {
-        trace("allowcgi: %s, localpath %s exists", config.allowcgi, localpath);
+        log(Level.Trace, "allowcgi: %s, localpath %s exists", config.allowcgi, localpath);
         if (pathIsCGI && config.allowcgi) {
-          trace("localpath %s is a CGI file", localpath);
+          log(Level.Trace, "localpath %s is a CGI file", localpath);
           return(response.serveCGI(request, config, filesystem));
         }
         if (pathIsFILE && !pathIsCGI && pathAllowed) {
-          trace("localpath %s is a normal file", localpath);
+          log(Level.Trace, "localpath %s is a normal file", localpath);
           return(response.serveStaticFile(request, filesystem));
         }
         if (pathIsDIR && config.dirAllowed(localroot, localpath)) {
-          trace("localpath %s is a directory [%s,%s]", localpath, config.redirectdir(), config.index());
+          log(Level.Trace, "localpath %s is a directory [%s,%s]", localpath, config.redirectdir(), config.index());
           if (config.redirectdir() && !finalrewrite) { return(redirectDirectory(request, response)); }
           if (config.redirect() && exists(localpath ~ "/" ~ config.index()) && !finalrewrite) { return(redirectCanonical(request, response)); }
           return(response.serveDirectory(request, config, filesystem));
@@ -109,7 +100,7 @@ class Router {
         return(response.forbidden());
       }
 
-      trace("redirect: %s %d", config.redirect, finalrewrite);
+      log(Level.Trace, "redirect: %s %d", config.redirect, finalrewrite);
       if(config.redirect && !finalrewrite) { return(this.redirectCanonical(request, response)); }
       return(response.notFound());  // Request is not hosted on this server
     }
@@ -119,7 +110,7 @@ class Router {
 
       bool serveACMEChallenge(ref Request request, ref Response response) {
         if (!request.isSecure && request.path.startsWith("/.well-known/acme-challenge/")) {
-          info("Router: serveACMEChallenge path: %s", request.path);
+          log(Level.Verbose, "Router: serveACMEChallenge path: %s", request.path);
           string token = baseName(request.path);
           string keyAuth;
           synchronized(getAcmeMutex()) {
@@ -136,23 +127,16 @@ class Router {
 
     // Redirect a directory browsing request to the index script
     void redirectDirectory(ref Request request, ref Response response){
-      trace("redirecting directory request to index page");
+      log(Level.Trace, "redirecting directory request to index page");
       request.redirectdir(config);
       return deliver(request, response, true);
     }
 
     // Perform a canonical redirect of a non-existing page to the index script
     void redirectCanonical(ref Request request, ref Response response){
-      trace("redirecting non-existing page (canonical url) to the index page");
+      log(Level.Trace, "redirecting non-existing page (canonical url) to the index page");
       request.url  = format("%s?%s", config.index, request.query);
       return deliver(request, response, true);
-    }
-
-    // Set the verbose level by string value
-    final @property int verbose(string verbose = "") {
-      auto sp = verbose.split(" ");
-      int nval = sp.length >= 2 ? to!int(sp[1]) : sp.length == 1 ? to!int(sp[0]) : NOTSET;
-      return logger.verbose(nval);
     }
 }
 
@@ -160,7 +144,7 @@ class Router {
 void runRequest(Router router, string request = "GET /dmd.d HTTP/1.1\nHost: localhost\n\n") {
   auto driver = new StringDriver(request);
   auto client = new Client(router, driver, 250);
-  custom(0, "TEST", "%s:%s %s", client.ip(), client.port(), request.splitLines()[0]);
+  log(Level.Verbose, "%s:%s %s", client.ip(), client.port(), request.splitLines()[0]);
   client.start();
   while (client.running()) {
     Thread.sleep(dur!"msecs"(2));
@@ -168,9 +152,9 @@ void runRequest(Router router, string request = "GET /dmd.d HTTP/1.1\nHost: loca
 }
 
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
+  tag(Level.Always, "FILE", "%s", __FILE__);
 
-  auto router = new Router("./www/", Address.init, NORMAL);
+  auto router = new Router("./www/", Address.init);
   router.runRequest("GET /dmd.d HTTP/1.1\nHost: localhost\n\n");
   router.runRequest("POST /dmd.d HTTP/1.1\nHost: localhost\n\n");
 

--- a/danode/router.d
+++ b/danode/router.d
@@ -52,8 +52,8 @@ class Router {
       if (!request.isValid) return(response.badRequest());
 
       string localroot = filesystem.localroot(request.shorthost());
-      log(Level.Trace, "%s:%s %s client (%s)", request.ip, request.port, (finalrewrite? "redirecting" : "routing"), request.id);
-      log(Level.Trace, "shorthost -> localroot: %s -> %s", request.shorthost(), localroot);
+      log(Level.Trace, "Router: [T] %s:%s %s client (%s)", request.ip, request.port, (finalrewrite? "redirecting" : "routing"), request.id);
+      log(Level.Trace, "Router: [T] shorthost '%s' -> localroot '%s'", request.shorthost(), localroot);
       if (request.shorthost() == "" || !exists(localroot)) return(response.domainNotFound());
 
       version(SSL) { if (serveACMEChallenge(request, response)) return; }
@@ -68,31 +68,31 @@ class Router {
       bool pathIsFILE  = pathExists && localpath.isFILE();
       bool pathIsDIR   = pathExists && localpath.isDIR();
       bool pathAllowed = localpath.isAllowed();
-      log(Level.Trace, "safePath result: '%s', isFILE: %s, isAllowed: %s, isCGI: %s", localpath, pathIsFILE, pathAllowed, pathIsCGI);
-      log(Level.Trace, "configfile at: %s%s", localroot, "/web.config");
-      log(Level.Trace, "request.host: %s, fqdn: %s", request.host, fqdn);
-      log(Level.Trace, "localpath: %s, exists ? %s", localpath, pathExists);
+      log(Level.Trace, "Router: [T] safePath result: '%s', isFILE: %s, isAllowed: %s, isCGI: %s", localpath, pathIsFILE, pathAllowed, pathIsCGI);
+      log(Level.Trace, "Router: [T] configfile at: %s%s", localroot, "/web.config");
+      log(Level.Trace, "Router: [T] request.host: %s, fqdn: %s", request.host, fqdn);
+      log(Level.Trace, "Router: [T] localpath: %s, exists ? %s", localpath, pathExists);
 
       version (SSL) {
         bool hasCert = hasCertificate(fqdn);
         if (request.isSecure != hasCert || request.host != fqdn) {
-          log(Level.Trace, "SSL redirect %s != %s for %s to fqdn: %s", request.isSecure, hasCert, request.host, fqdn);
+          log(Level.Trace, "Router: [T] SSL redirect %s != %s for %s to fqdn: %s", request.isSecure, hasCert, request.host, fqdn);
           return(response.redirect(request, fqdn, hasCert));
         }
       } else { if (request.host != fqdn) { return(response.redirect(request, fqdn, false)); } }
 
       if (pathExists) {
-        log(Level.Trace, "allowcgi: %s, localpath %s exists", config.allowcgi, localpath);
+        log(Level.Trace, "Router: [T] allowcgi: %s, localpath %s exists", config.allowcgi, localpath);
         if (pathIsCGI && config.allowcgi) {
-          log(Level.Trace, "localpath %s is a CGI file", localpath);
+          log(Level.Trace, "Router: [T] localpath %s is a CGI file", localpath);
           return(response.serveCGI(request, config, filesystem));
         }
         if (pathIsFILE && !pathIsCGI && pathAllowed) {
-          log(Level.Trace, "localpath %s is a normal file", localpath);
+          log(Level.Trace, "Router: [T] localpath %s is a normal file", localpath);
           return(response.serveStaticFile(request, filesystem));
         }
         if (pathIsDIR && config.dirAllowed(localroot, localpath)) {
-          log(Level.Trace, "localpath %s is a directory [%s,%s]", localpath, config.redirectdir(), config.index());
+          log(Level.Trace, "Router: [T] localpath %s is a directory [%s,%s]", localpath, config.redirectdir(), config.index());
           if (config.redirectdir() && !finalrewrite) { return(redirectDirectory(request, response)); }
           if (config.redirect() && exists(localpath ~ "/" ~ config.index()) && !finalrewrite) { return(redirectCanonical(request, response)); }
           return(response.serveDirectory(request, config, filesystem));
@@ -100,7 +100,7 @@ class Router {
         return(response.forbidden());
       }
 
-      log(Level.Trace, "redirect: %s %d", config.redirect, finalrewrite);
+      log(Level.Trace, "Router: [T] Redirect: %s %d", config.redirect, finalrewrite);
       if(config.redirect && !finalrewrite) { return(this.redirectCanonical(request, response)); }
       return(response.notFound());  // Request is not hosted on this server
     }
@@ -110,7 +110,7 @@ class Router {
 
       bool serveACMEChallenge(ref Request request, ref Response response) {
         if (!request.isSecure && request.path.startsWith("/.well-known/acme-challenge/")) {
-          log(Level.Verbose, "Router: serveACMEChallenge path: %s", request.path);
+          log(Level.Verbose, "Router: [I] serveACMEChallenge path: %s", request.path);
           string token = baseName(request.path);
           string keyAuth;
           synchronized(getAcmeMutex()) {
@@ -127,14 +127,14 @@ class Router {
 
     // Redirect a directory browsing request to the index script
     void redirectDirectory(ref Request request, ref Response response){
-      log(Level.Trace, "redirecting directory request to index page");
+      log(Level.Trace, "Router: [T] Redirecting directory request to index page");
       request.redirectdir(config);
       return deliver(request, response, true);
     }
 
     // Perform a canonical redirect of a non-existing page to the index script
     void redirectCanonical(ref Request request, ref Response response){
-      log(Level.Trace, "redirecting non-existing page (canonical url) to the index page");
+      log(Level.Trace, "Router: [T] Redirecting canonical url to the index page");
       request.url  = format("%s?%s", config.index, request.query);
       return deliver(request, response, true);
     }
@@ -144,7 +144,7 @@ class Router {
 void runRequest(Router router, string request = "GET /dmd.d HTTP/1.1\nHost: localhost\n\n") {
   auto driver = new StringDriver(request);
   auto client = new Client(router, driver, 250);
-  log(Level.Verbose, "%s:%s %s", client.ip(), client.port(), request.splitLines()[0]);
+  log(Level.Verbose, "Router: [I] %s:%s %s", client.ip(), client.port(), request.splitLines()[0]);
   client.start();
   while (client.running()) {
     Thread.sleep(dur!"msecs"(2));

--- a/danode/server.d
+++ b/danode/server.d
@@ -160,7 +160,7 @@ void main(string[] args) {
   int    backlog      = 100;
   int    verbose      = Level.Verbose;
   bool   keyoff       = false;
-  string logFolder    = "log/";
+  string logFolder    = "logs/";
   string wwwFolder    = "www/";
   string sslFolder    = ".ssl/";
   string sslKey       = "server.key";

--- a/danode/server.d
+++ b/danode/server.d
@@ -1,16 +1,16 @@
 module danode.server;
 
 import danode.imports;
-import danode.functions : Msecs, sISelect;
+import danode.functions : Msecs, sISelect, resolveFolder;
 import danode.client : Client;
 import danode.interfaces : DriverInterface;
 import danode.http : HTTP;
 import danode.router : Router;
-import danode.log;
+import danode.log : initLogs, abort, log, tag, error, Level;
 
 version(SSL) {
   import danode.acme : checkAndRenew;
-  import danode.ssl : generateKey, initSSL, closeSSL;
+  import danode.ssl : loadSSL, closeSSL;
   import danode.https : HTTPS;
 }
 
@@ -19,34 +19,38 @@ immutable int MAX_CLIENTS_PER_IP = 32;
 
 class Server : Thread {
   private:
-    Socket            socket;           // The server socket
-    SocketSet         set;              // SocketSet for server socket and client listeners
-    Client[]          clients;          // List of clients
-    bool              terminated;       // Server running
-    SysTime           starttime;        // Start time of the server
-    Router            router;           // Router to route requests
+    Socket            socket;                 // The server socket
+    SocketSet         set;                    // SocketSet for server socket and client listeners
+    Client[]          clients;                // List of clients
+    bool              terminated;             // Server running
+    SysTime           starttime;              // Start time of the server
+    Router            router;                 // Router to route requests
+  public:
+    string wwwFolder    = "www/";
+
     version(SSL) {
-      Socket          sslsocket;        // SSL / HTTPs socket
+      private:
+        Socket sslsocket;                     // SSL / HTTPs socket
+        string ssl        = "server.key";
+        string account    = "account.key";
       public:
-        string certDir = ".ssl/";
-        string keyFile = ".ssl/server.key";
-        string accountKey = ".ssl/account.key";
+        string sslPath  = ".ssl/";
     }
 
   public:
-    this(ushort port = 80, int backlog = 100, string wwwRoot = "./www/", 
-         string certDir = ".ssl/", string keyFile = ".ssl/server.key", string accountKey = ".ssl/account.key", int verbose = NORMAL) {
-      this.starttime = Clock.currTime();            // Start the timer
-      this.socket = initialize(port, backlog);      // Create the HTTP socket
-      this.router = new Router(wwwRoot, this.socket.localAddress(), verbose);   // Start the router
+    this(ushort port = 80, int backlog = 100, string wwwFolder = "www/",
+         string sslFolder = ".ssl/", string sslKey = "server.key", string accountKey = "account.key") {
+      starttime = Clock.currTime();                             // Start the timer
+      socket = initialize(port, backlog);                       // Create the HTTP socket
+      router = new Router(wwwFolder, socket.localAddress());    // Start the router
       version(SSL) {
-        this.certDir = certDir;
-        this.keyFile = keyFile;
-        this.accountKey = accountKey;
-        this.sslsocket = initialize(443, backlog);  // Create the SSL / HTTPs socket
+        sslPath = sslFolder.resolveFolder();
+        ssl = sslKey;
+        account = accountKey;
+        sslsocket = initialize(443, backlog);  // Create the SSL / HTTPs socket
       }
       set = new SocketSet(1);                       // Create a server socket set
-      custom(0, "SERVER", "server '%s' created backlog: %d", this.hostname(), backlog);
+      log(Level.Always, "server '%s' created backlog: %d", this.hostname(), backlog);
       super(&run);
     }
 
@@ -59,17 +63,15 @@ class Server : Thread {
         socket.blocking = false;
         socket.bind(new InternetAddress(port));
         socket.listen(backlog);
-        custom(0, "SERVER", "socket listening on port %s", port);
-      } catch(Exception e) {
-        abort(format("unable to bind socket on port %s\n%s", port, e.msg), -1);
-      }
+        log(Level.Always, "socket listening on port %s", port);
+      } catch(Exception e) { abort(format("unable to bind socket on port %s\n%s", port, e.msg), -1); }
       return socket;
     }
 
     // Accept an incoming connection and create a client object
     final void accept(ref Appender!(Client[]) persistent, Socket socket, bool secure = false) {
       if (set.sISelect(socket) <= 0 || nAlive() >= MAX_CLIENTS) return;
-      custom(3, "SERVER", "accepting %s request", secure ? "HTTPs" : "HTTP");
+      log(Level.Trace, "accepting %s request", secure ? "HTTPs" : "HTTP");
       try {
           DriverInterface driver = null;
           if (!secure) driver = new HTTP(socket.accept(), false);
@@ -79,7 +81,7 @@ class Server : Thread {
           client.start();
           if (nAliveFromIP(client.ip) <= MAX_CLIENTS_PER_IP) {
             persistent.put(client);
-          } else { warning("rate limit exceeded for %s", client.ip); client.stop(); }
+          } else { log(Level.Always, "rate limit exceeded for %s", client.ip); client.stop(); }
       } catch(Exception e) { error("unable to accept connection: %s", e.msg); }
     }
 
@@ -107,19 +109,17 @@ class Server : Thread {
     final @property Duration uptime() const { return(Clock.currTime() - starttime); }
 
      // Print some server information
-    final @property void info() {
-      custom(0, "SERVER", "uptime %s\n[INFO]   # of connections: %d / %d", uptime(), nAlive(), clients.length);
-    }
+    final @property void info() { log(Level.Always, "uptime %s, connections: %d / %d", uptime(), nAlive(), clients.length); }
     
-    // Hostanme of the server
-    final @property string hostname() { return(this.socket.hostName()); }
+    // Hostname of the server
+    final @property string hostname() { return(socket.hostName()); }
+    final @property string sslKey() { return(sslPath ~ ssl); }
+    final @property string accountKey() { return(sslPath ~ account); }
 
     // Number of alive connections
     final @property long nAlive() {
       long sum = 0; foreach(Client client; clients){ if(client.running){ sum++; } } return sum; 
     }
-
-    final @property int verbose(string verbose = "") { return(router.verbose(verbose)); } // Verbose level
 
     final void run() {
       Appender!(Client[]) persistent;
@@ -137,16 +137,13 @@ class Server : Thread {
           clients = persistent.data;
           if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted files & expiring certificates every day
             router.scan();
-            version(SSL) { checkAndRenew(certDir, keyFile, accountKey); }
+            version(SSL) { checkAndRenew(sslPath, sslKey, accountKey); }
             lastScan = Clock.currTime();
           }
-        } catch(Exception e) {
-          error("Unspecified top level server exception: %s", e.msg);
-        } catch(Error e) {
-          error("Unspecified top level server error: %s", e.msg);
-        }
+        } catch(Exception e) { error("Unspecified top level server exception: %s", e.msg);
+        } catch(Error e) { error("Unspecified top level server error: %s", e.msg); }
       }
-      custom(0, "SERVER", "Server socket closed, running: %s", running);
+      log(Level.Always, "Server socket closed, running: %s", running);
       socket.close();
       version (SSL) { sslsocket.closeSSL(); }
     }
@@ -156,45 +153,45 @@ void parseKeyInput(ref Server server){
   string line = chomp(stdin.readln());
   if (line.startsWith("quit")) server.stop();
   if (line.startsWith("info")) server.info();
-  if (line.startsWith("verbose")) server.verbose(line);
 }
 
 void main(string[] args) {
   version(unittest){ ushort port = 8080; }else{ ushort port = 80; }
   int    backlog      = 100;
-  int    verbose      = NORMAL;
+  int    verbose      = Level.Verbose;
   bool   keyoff       = false;
-  string certDir      = ".ssl/";
-  string keyFile      = ".ssl/server.key";
-  string accountKey   = ".ssl/account.key";
-  string wwwRoot      = "./www/";
-  getopt(args, "port|p",     &port,         // Port to listen on
-               "backlog|b",  &backlog,      // Backlog of clients supported
-               "keyoff|k",   &keyoff,       // Keyboard on or off
-               "certDir",    &certDir,      // Location of SSL certificates
-               "keyFile",    &keyFile,      // Server private key
-               "accountKey", &accountKey,   // Server Let's encrypt account key
-               "wwwRoot",    &wwwRoot,      // Server www root folder
-               "verbose|v",  &verbose);     // Verbose level (via commandline)
+  string logFolder    = "log/";
+  string wwwFolder    = "www/";
+  string sslFolder    = ".ssl/";
+  string sslKey       = "server.key";
+  string accountKey   = "account.key";
+  
+  getopt(args, "port|p",      &port,         // Port to listen on
+               "backlog|b",   &backlog,      // Backlog of clients supported
+               "keyoff|k",    &keyoff,       // Keyboard on or off
+               "log",         &logFolder,    // Location of LOG
+               "www",         &wwwFolder,    // Server www root folder
+               "ssl",         &sslFolder,    // Location of SSL certificates
+               "sslKey",      &sslKey,       // Server private key
+               "accountKey",  &accountKey,   // Server Let's encrypt account key
+               "verbose|v",   &verbose);     // Verbose level (via commandline)
   version (unittest) {
     // Do nothing, unittests will run
   } else {
+    logFolder.resolveFolder().initLogs(verbose);
     version (Posix) {
       import core.sys.posix.signal : signal, SIGPIPE;
       import danode.signals : handle_signal;
       signal(SIGPIPE, &handle_signal);
     }
     version (Windows) {
-      warning("-k has been set to true, we cannot handle keyboard input under windows at the moment");
+      log(Level.Always, "-k has been set to true, we cannot handle keyboard input under windows at the moment");
       keyoff = true;
     }
-
-    auto server = new Server(port, backlog, wwwRoot, certDir, keyFile, accountKey, verbose);
+    auto server = new Server(port, backlog, wwwFolder, sslFolder, sslKey, accountKey);
     version (SSL) {
-      keyFile.generateKey();
-      accountKey.generateKey();
-      checkAndRenew(certDir, keyFile, accountKey);
-      server.initSSL();  // Load SSL certificates, using the server key
+      loadSSL(server.sslPath, server.sslKey);                             // Load SSL certificates
+      checkAndRenew(server.sslPath, server.sslKey, server.accountKey);    // checkAndRenew SSL certificates
     }
     server.start();
     while (server.running) {
@@ -202,17 +199,17 @@ void main(string[] args) {
       stdout.flush();
       Thread.sleep(dur!"msecs"(250));
     }
-    info("server shutting down: %d", server.running);
+    log(Level.Always, "server shutting down: %d", server.running);
     server.info();
   }
 }
 
 unittest {
-  custom(0, "FILE", "%s", __FILE__);
+  tag(Level.Always, "FILE", "%s", __FILE__);
   version(SSL) {
-    custom(0, "TEST", "SSL support");
+    tag(Level.Always, "TEST", "SSL support");
   }else{
-    custom(0, "TEST", "No SSL support");
+    tag(Level.Always, "TEST", "No SSL support");
   }
 }
 

--- a/danode/server.d
+++ b/danode/server.d
@@ -50,7 +50,7 @@ class Server : Thread {
         sslsocket = initialize(443, backlog);  // Create the SSL / HTTPs socket
       }
       set = new SocketSet(1);                       // Create a server socket set
-      log(Level.Always, "server '%s' created backlog: %d", this.hostname(), backlog);
+      log(Level.Always, "Server '%s' created backlog: %d", this.hostname(), backlog);
       super(&run);
     }
 
@@ -63,7 +63,7 @@ class Server : Thread {
         socket.blocking = false;
         socket.bind(new InternetAddress(port));
         socket.listen(backlog);
-        log(Level.Always, "socket listening on port %s", port);
+        log(Level.Always, "Socket listening port %s", port);
       } catch(Exception e) { abort(format("unable to bind socket on port %s\n%s", port, e.msg), -1); }
       return socket;
     }
@@ -71,7 +71,7 @@ class Server : Thread {
     // Accept an incoming connection and create a client object
     final void accept(ref Appender!(Client[]) persistent, Socket socket, bool secure = false) {
       if (set.sISelect(socket) <= 0 || nAlive() >= MAX_CLIENTS) return;
-      log(Level.Trace, "accepting %s request", secure ? "HTTPs" : "HTTP");
+      log(Level.Trace, "Accepting %s request", secure ? "HTTPs" : "HTTP");
       try {
           DriverInterface driver = null;
           if (!secure) driver = new HTTP(socket.accept(), false);
@@ -81,8 +81,8 @@ class Server : Thread {
           client.start();
           if (nAliveFromIP(client.ip) <= MAX_CLIENTS_PER_IP) {
             persistent.put(client);
-          } else { log(Level.Always, "rate limit exceeded for %s", client.ip); client.stop(); }
-      } catch(Exception e) { error("unable to accept connection: %s", e.msg); }
+          } else { log(Level.Always, "Rate limit exceeded [%s]", client.ip); client.stop(); }
+      } catch(Exception e) { error("Unable to accept connection: %s", e.msg); }
     }
 
     // is the server still running ?
@@ -109,7 +109,7 @@ class Server : Thread {
     final @property Duration uptime() const { return(Clock.currTime() - starttime); }
 
      // Print some server information
-    final @property void info() { log(Level.Always, "uptime %s, connections: %d / %d", uptime(), nAlive(), clients.length); }
+    final @property void info() { log(Level.Always, "Uptime %s, Connections: %d / %d", uptime(), nAlive(), clients.length); }
     
     // Hostname of the server
     final @property string hostname() { return(socket.hostName()); }
@@ -185,7 +185,7 @@ void main(string[] args) {
       signal(SIGPIPE, &handle_signal);
     }
     version (Windows) {
-      log(Level.Always, "-k has been set to true, we cannot handle keyboard input under windows at the moment");
+      log(Level.Always, "-k was set to true. However, keyboard input under windows is not supported");
       keyoff = true;
     }
     auto server = new Server(port, backlog, wwwFolder, sslFolder, sslKey, accountKey);
@@ -199,7 +199,7 @@ void main(string[] args) {
       stdout.flush();
       Thread.sleep(dur!"msecs"(250));
     }
-    log(Level.Always, "server shutting down: %d", server.running);
+    log(Level.Always, "Server shutting down: %d", server.running);
     server.info();
   }
 }

--- a/danode/server.d
+++ b/danode/server.d
@@ -10,7 +10,7 @@ import danode.log;
 
 version(SSL) {
   import danode.acme : checkAndRenew;
-  import danode.ssl : initSSL, closeSSL;
+  import danode.ssl : generateKey, initSSL, closeSSL;
   import danode.https : HTTPS;
 }
 
@@ -191,6 +191,8 @@ void main(string[] args) {
 
     auto server = new Server(port, backlog, wwwRoot, certDir, keyFile, accountKey, verbose);
     version (SSL) {
+      keyFile.generateKey();
+      accountKey.generateKey();
       checkAndRenew(certDir, keyFile, accountKey);
       server.initSSL();  // Load SSL certificates, using the server key
     }

--- a/danode/server.d
+++ b/danode/server.d
@@ -113,8 +113,10 @@ class Server : Thread {
     
     // Hostname of the server
     final @property string hostname() { return(socket.hostName()); }
-    final @property string sslKey() { return(sslPath ~ ssl); }
-    final @property string accountKey() { return(sslPath ~ account); }
+    version(SSL) {
+      final @property string sslKey() { return(sslPath ~ ssl); }
+      final @property string accountKey() { return(sslPath ~ account); }
+    }
 
     // Number of alive connections
     final @property long nAlive() {

--- a/danode/signals.d
+++ b/danode/signals.d
@@ -5,15 +5,15 @@ version(Posix) {
   import core.sys.posix.signal : SIGPIPE;
 
   import danode.imports;
-  import danode.log : cverbose;
+  import danode.log : cv;
 
   extern(C) @nogc nothrow void handle_signal(int signal) {
     switch (signal) {
       case SIGPIPE:
-        if(atomicLoad(cverbose) > 1) write(2, cast(const(void*)) "[SIG]    Broken pipe caught, and ignored\n\0".ptr, 41);
+        if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    Broken pipe caught, and ignored\n\0".ptr, 41);
         break;
       default:
-        if(atomicLoad(cverbose) > 1) write(2, cast(const(void*)) "[SIG]    Caught\n\0".ptr, 17);
+        if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    Caught\n\0".ptr, 17);
         break;
     }
   }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -6,7 +6,7 @@ version(SSL) {
 
   import danode.imports;
   import danode.client;
-  import danode.log : custom, warning, info, error;
+  import danode.log : log, error, Level;
   import danode.server : Server;
   import danode.response : Response;
 
@@ -29,19 +29,19 @@ version(SSL) {
     // C callback function to switch SSL contexts after hostname lookup
     static void switchContext(SSL* ssl, int *ad, void *arg) {
       string hostname = to!(string)(cast(const(char*)) SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
-      custom(1, "SSL", "looking for hostname: %s", hostname);
-      if(hostname is null) { custom(1, "WARN", "Client no SNI support, using default: contexts[0]"); return; }
+      log(Level.Verbose, "looking for hostname: %s", hostname);
+      if(hostname is null) { log(Level.Verbose, "Client no SNI support, using default: contexts[0]"); return; }
       ptrdiff_t idx = findContext(hostname);
       if (idx >= 0) { 
-        custom(1, "SSL", "switching SSL context to %s", hostname); 
+        log(Level.Verbose, "switching SSL context to %s", hostname); 
         SSL_set_SSL_CTX(ssl, contexts[idx].context);
-      }else{ custom(1, "WARN", "callback failed to find certificate for %s", hostname); }
+      }else{ error("callback failed to find certificate for %s", hostname); }
     }
   }
 
   void generateKey(string path, int bits = 4096) {
     if (exists(path)) return;
-    custom(0, "SSL", "ACME: generating %d-bit RSA key at %s", bits, path);
+    log(Level.Always, "ACME: generating %d-bit RSA key at %s", bits, path);
     EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new_id(6, null);  // 6 = EVP_PKEY_RSA
     scope(exit) EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_keygen_init(ctx);
@@ -73,10 +73,10 @@ version(SSL) {
     SSL_CTX_set1_groups_list(ctx, "X25519:P-256:P-384");
 
     if (exists(chainFile) && isFile(chainFile)) {
-      custom(1, "SSL", "loading certificate+chain from file: %s", chainFile);
+      log(Level.Verbose, "loading certificate+chain from file: %s", chainFile);
       sslAssert(SSL_CTX_use_certificate_chain_file(ctx, cast(const char*) toStringz(chainFile)) > 0);
     } else {
-      custom(1, "WARN", "No chain file for %s", chainFile);
+      log(Level.Verbose, "Warning: No chain file for %s", chainFile);
       return(null);
     }
     sslAssert(SSL_CTX_use_PrivateKey_file(ctx, cast(const char*) toStringz(keyFile), 1) > 0);
@@ -87,7 +87,7 @@ version(SSL) {
   // Does the hostname requested have a certificate ?
   bool hasCertificate(string hostname) {
     bool found = (findContext(hostname) >= 0);
-    custom(2, "SSL", "'%s' certificate? %s", hostname, found);
+    log(Level.Trace, "'%s' certificate? %s", hostname, found);
     return found;
   }
 
@@ -96,7 +96,7 @@ version(SSL) {
     int err = SSL_get_error(ssl, retcode);
     switch (err) {
       case SSL_ERROR_NONE: break;
-      default: custom(2, "SSL", "SSL_get_error %s %d", err, retcode); break;
+      default: error("SSL_get_error %s %d", err, retcode); break;
     }
     return(err);
   }
@@ -107,20 +107,17 @@ version(SSL) {
     for(size_t x = 0; x < hostname.length; x++) { ctx.hostname[x] = hostname[x]; }
     ctx.hostname[hostname.length] = '\0';
     ctx.context = createCTX(chainFile, keyFile);
-    if (ctx.context is null) { warning("SSL: failed to create context for %s", hostname); return ctx; }
-    custom(1, "SSL", "context created for certificate: %s", fromStringz(ctx.hostname));
+    if (ctx.context is null) { error("SSL: failed to create context for %s", hostname); return ctx; }
+    log(Level.Verbose, "context created for certificate: %s", fromStringz(ctx.hostname));
     SSL_CTX_callback_ctrl(ctx.context,SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cast(ExternC!(void function())) &switchContext);
     return(ctx);
   }
 
-  // loads all chain files in the server.certDir, using server.keyFile
-  void initSSL(Server server) { reloadSSL(server.certDir, server.keyFile); }
-
   // Reload all SSL contexts from certDir without restarting the server
-  void reloadSSL(string certDir = ".ssl/", string keyFile = ".ssl/server.key") {
-    custom(0, "SSL", "loading Deimos.openSSL, certDir: %s, keyFile: %s", certDir, keyFile);
-    if (!exists(certDir) || !isDir(certDir)) { warning("SSL cert dir '%s' not found", certDir); return; }
-    if (!exists(keyFile) || !isFile(keyFile)) { warning("SSL key file '%s' not found", keyFile); return; }
+  void loadSSL(string certDir = ".ssl/", string sslKey = ".ssl/server.key") {
+    log(Level.Verbose, "loading Deimos.openSSL, certDir: %s, sslKey: %s", certDir, sslKey);
+    if (!exists(certDir) || !isDir(certDir)) { error("SSL cert dir '%s' not found", certDir); return; }
+    if (!exists(sslKey) || !isFile(sslKey)) { sslKey.generateKey(); }
 
     SSLcontext[] localContexts;
     foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
@@ -128,21 +125,21 @@ version(SSL) {
         string hostname = baseName(d.name, ".chain");
         if (hostname.length < 255) {
           string chainFile = d.name;
-          info("reloading certificate at: '%s'", chainFile);
-          auto lc = loadContext(chainFile, hostname, keyFile);
+          log(Level.Verbose, "reloading certificate at: '%s'", chainFile);
+          auto lc = loadContext(chainFile, hostname, sslKey);
           if (lc.context !is null) localContexts ~= lc;
         }
       }
     }
     contexts = localContexts;  // atomic single assignment
-    custom(0, "HTTPS", "(re)loaded %s SSL certificates", contexts.length);
+    log(Level.Always, "(re)loaded %s SSL certificates", contexts.length);
   }
 
   // Close the server SSL socket, and clean up the different contexts
   void closeSSL(Socket socket) {
-    custom(1, "HTTPS", "closing server SSL socket");
+    log(Level.Verbose, "closing server SSL socket");
     socket.close();
-    custom(1, "HTTPS", "cleaning up %d HTTPS contexts", contexts.length);
+    log(Level.Verbose, "cleaning up %d HTTPS contexts", contexts.length);
     foreach (ref ctx; contexts) { SSL_CTX_free(ctx.context); }
     contexts = null;
   }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -1,12 +1,12 @@
 module danode.ssl;
 
-import danode.log : custom, warning, info;
-
 version(SSL) {
+  import danode.imports;
   import danode.includes;
 
   import danode.imports;
   import danode.client;
+  import danode.log : custom, warning, info, error;
   import danode.server : Server;
   import danode.response : Response;
 
@@ -29,14 +29,29 @@ version(SSL) {
     // C callback function to switch SSL contexts after hostname lookup
     static void switchContext(SSL* ssl, int *ad, void *arg) {
       string hostname = to!(string)(cast(const(char*)) SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
-      custom(1, "HTTPS", "looking for hostname: %s", hostname);
+      custom(1, "SSL", "looking for hostname: %s", hostname);
       if(hostname is null) { custom(1, "WARN", "Client no SNI support, using default: contexts[0]"); return; }
       ptrdiff_t idx = findContext(hostname);
       if (idx >= 0) { 
-        custom(1, "HTTPS", "switching SSL context to %s", hostname); 
+        custom(1, "SSL", "switching SSL context to %s", hostname); 
         SSL_set_SSL_CTX(ssl, contexts[idx].context);
       }else{ custom(1, "WARN", "callback failed to find certificate for %s", hostname); }
     }
+  }
+
+  void generateKey(string path, int bits = 4096) {
+    if (exists(path)) return;
+    custom(0, "SSL", "ACME: generating %d-bit RSA key at %s", bits, path);
+    EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new_id(6, null);  // 6 = EVP_PKEY_RSA
+    scope(exit) EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_keygen_init(ctx);
+    EVP_PKEY_CTX_ctrl(ctx, 6, 8, 1, bits, null);  // set_rsa_keygen_bits: op=KEYGEN(8), ctrl=KEYBITS(1)
+    EVP_PKEY* pkey;
+    if (EVP_PKEY_keygen(ctx, &pkey) <= 0) { error("ACME: keygen failed for %s", path); return; }
+    scope(exit) EVP_PKEY_free(pkey);
+    BIO* bio = BIO_new_file(toStringz(path), "w");
+    scope(exit) BIO_free(bio);
+    PEM_write_bio_PrivateKey(bio, pkey, null, null, 0, null, null);
   }
 
   ptrdiff_t findContext(string hostname) {
@@ -58,7 +73,7 @@ version(SSL) {
     SSL_CTX_set1_groups_list(ctx, "X25519:P-256:P-384");
 
     if (exists(chainFile) && isFile(chainFile)) {
-      custom(1, "HTTPS", "loading certificate+chain from file: %s", chainFile);
+      custom(1, "SSL", "loading certificate+chain from file: %s", chainFile);
       sslAssert(SSL_CTX_use_certificate_chain_file(ctx, cast(const char*) toStringz(chainFile)) > 0);
     } else {
       custom(1, "WARN", "No chain file for %s", chainFile);
@@ -72,35 +87,16 @@ version(SSL) {
   // Does the hostname requested have a certificate ?
   bool hasCertificate(string hostname) {
     bool found = (findContext(hostname) >= 0);
-    custom(2, "HTTPS", "'%s' certificate? %s", hostname, found);
+    custom(2, "SSL", "'%s' certificate? %s", hostname, found);
     return found;
   }
 
-  // Should be used after SSL_connect(), SSL_accept(), SSL_do_handshake(), 
-  // SSL_read_ex(), SSL_read(), SSL_peek_ex(), SSL_peek(), SSL_write_ex() 
-  // or SSL_write() on the ssl
+  // Should be used after all SSL class
   int checkForError(SSL* ssl, Socket socket, int retcode) {
     int err = SSL_get_error(ssl, retcode);
     switch (err) {
-      case SSL_ERROR_NONE:
-        /* warning("SSL_ERROR_NONE"); */ break;
-      case SSL_ERROR_SSL:
-        /* warning("SSL_ERROR_SSL"); */ break;
-      case SSL_ERROR_ZERO_RETURN:
-        /* warning("SSL_ERROR_ZERO_RETURN"); */ break;
-      case SSL_ERROR_WANT_READ:
-        /* warning("SSL_ERROR_WANT_READ"); */ break;
-      case SSL_ERROR_WANT_WRITE:
-        /* warning("SSL_ERROR_WANT_WRITE"); */ break;
-      case SSL_ERROR_WANT_CONNECT:
-        /* warning("SSL_ERROR_WANT_CONNECT"); */ break;
-      case SSL_ERROR_WANT_ACCEPT:
-        /* warning("SSL_ERROR_WANT_ACCEPT"); */ break;
-      case SSL_ERROR_WANT_X509_LOOKUP:
-        /* warning("SSL_ERROR_WANT_X509_LOOKUP"); */ break;
-      case SSL_ERROR_SYSCALL:
-        /* warning("[ERROR]  SSL_ERROR_SYSCALL: RETURN: %d", retcode); */ break;
-      default: /*  warning("[ERROR]  SSL_ERROR Error %d %d", err, retcode); */ break;
+      case SSL_ERROR_NONE: break;
+      default: custom(2, "SSL", "SSL_get_error %s %d", err, retcode); break;
     }
     return(err);
   }
@@ -111,21 +107,18 @@ version(SSL) {
     for(size_t x = 0; x < hostname.length; x++) { ctx.hostname[x] = hostname[x]; }
     ctx.hostname[hostname.length] = '\0';
     ctx.context = createCTX(chainFile, keyFile);
-    if (ctx.context is null) { warning("HTTPS: failed to create context for %s", hostname); return ctx; }
-    custom(1, "HTTPS", "context created for certificate: %s", to!string(ctx.hostname.ptr));
+    if (ctx.context is null) { warning("SSL: failed to create context for %s", hostname); return ctx; }
+    custom(1, "SSL", "context created for certificate: %s", fromStringz(ctx.hostname));
     SSL_CTX_callback_ctrl(ctx.context,SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cast(ExternC!(void function())) &switchContext);
     return(ctx);
   }
 
   // loads all chain files in the server.certDir, using server.keyFile
-  void initSSL(Server server, VERSION v = SSL23) {
-    custom(0, "HTTPS", "loading Deimos.openSSL, certDir: %s, keyFile: %s, SSL:%s", server.certDir, server.keyFile, v);
-    reloadSSL(server.certDir, server.keyFile);
-  }
+  void initSSL(Server server) { reloadSSL(server.certDir, server.keyFile); }
 
   // Reload all SSL contexts from certDir without restarting the server
   void reloadSSL(string certDir = ".ssl/", string keyFile = ".ssl/server.key") {
-    custom(0, "HTTPS", "(re)loading SSL certificates from: %s", certDir);
+    custom(0, "SSL", "loading Deimos.openSSL, certDir: %s, keyFile: %s", certDir, keyFile);
     if (!exists(certDir) || !isDir(certDir)) { warning("SSL cert dir '%s' not found", certDir); return; }
     if (!exists(keyFile) || !isFile(keyFile)) { warning("SSL key file '%s' not found", keyFile); return; }
 
@@ -154,15 +147,9 @@ version(SSL) {
     contexts = null;
   }
 
-  void sslAssert(bool ret) { 
-    if (!ret) { ERR_print_errors_fp(null); throw new Exception("SSL_ERROR"); }
-  }
+  void sslAssert(bool ret) { if (!ret) { ERR_print_errors_fp(null); throw new Exception("SSL_ERROR"); } }
 
   unittest {
     custom(0, "FILE", "%s", __FILE__);
-  }
-} else {// End version SSL
-  unittest {
-    custom(0, "WARN", "Skipping unittest for: '%s'", __FILE__);
   }
 }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -6,8 +6,7 @@ version(SSL) {
 
   import danode.imports;
   import danode.client;
-  import danode.log : log, error, Level;
-  import danode.server : Server;
+  import danode.log : log, tag, error, Level;
   import danode.response : Response;
 
   // SSL context structure, stored relation between hostname 
@@ -147,6 +146,6 @@ version(SSL) {
   void sslAssert(bool ret) { if (!ret) { ERR_print_errors_fp(null); throw new Exception("SSL_ERROR"); } }
 
   unittest {
-    custom(0, "FILE", "%s", __FILE__);
+    tag(Level.Always, "FILE", "%s", __FILE__);
   }
 }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -29,25 +29,25 @@ version(SSL) {
     // C callback function to switch SSL contexts after hostname lookup
     static void switchContext(SSL* ssl, int *ad, void *arg) {
       string hostname = to!(string)(cast(const(char*)) SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
-      log(Level.Verbose, "looking for hostname: %s", hostname);
-      if(hostname is null) { log(Level.Verbose, "Client no SNI support, using default: contexts[0]"); return; }
+      log(Level.Verbose, "SSL: [I] Looking for hostname: %s", hostname);
+      if(hostname is null) { log(Level.Verbose, "SSL: [W] Client no SNI support, using default: contexts[0]"); return; }
       ptrdiff_t idx = findContext(hostname);
       if (idx >= 0) { 
-        log(Level.Verbose, "switching SSL context to %s", hostname); 
+        log(Level.Verbose, "SSL: [I] Switching SSL context to %s", hostname); 
         SSL_set_SSL_CTX(ssl, contexts[idx].context);
-      }else{ error("callback failed to find certificate for %s", hostname); }
+      }else{ error("SSL: Callback failed to find certificate for %s", hostname); }
     }
   }
 
   void generateKey(string path, int bits = 4096) {
-    if (exists(path)) return;
-    log(Level.Always, "ACME: generating %d-bit RSA key at %s", bits, path);
+    if (path.exists()) return;
+    log(Level.Always, "SSL: Generating %d-bit RSA key at %s", bits, path);
     EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new_id(6, null);  // 6 = EVP_PKEY_RSA
     scope(exit) EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_keygen_init(ctx);
     EVP_PKEY_CTX_ctrl(ctx, 6, 8, 1, bits, null);  // set_rsa_keygen_bits: op=KEYGEN(8), ctrl=KEYBITS(1)
     EVP_PKEY* pkey;
-    if (EVP_PKEY_keygen(ctx, &pkey) <= 0) { error("ACME: keygen failed for %s", path); return; }
+    if (EVP_PKEY_keygen(ctx, &pkey) <= 0) { error("SSL: Keygen failed for %s", path); return; }
     scope(exit) EVP_PKEY_free(pkey);
     BIO* bio = BIO_new_file(toStringz(path), "w");
     scope(exit) BIO_free(bio);
@@ -73,10 +73,10 @@ version(SSL) {
     SSL_CTX_set1_groups_list(ctx, "X25519:P-256:P-384");
 
     if (exists(chainFile) && isFile(chainFile)) {
-      log(Level.Verbose, "loading certificate+chain from file: %s", chainFile);
+      log(Level.Verbose, "SSL: [I] Loading certificate+chain from file: %s", chainFile);
       sslAssert(SSL_CTX_use_certificate_chain_file(ctx, cast(const char*) toStringz(chainFile)) > 0);
     } else {
-      log(Level.Verbose, "Warning: No chain file for %s", chainFile);
+      log(Level.Verbose, "SSL: [W] No chain file for %s", chainFile);
       return(null);
     }
     sslAssert(SSL_CTX_use_PrivateKey_file(ctx, cast(const char*) toStringz(keyFile), 1) > 0);
@@ -87,7 +87,7 @@ version(SSL) {
   // Does the hostname requested have a certificate ?
   bool hasCertificate(string hostname) {
     bool found = (findContext(hostname) >= 0);
-    log(Level.Trace, "'%s' certificate? %s", hostname, found);
+    log(Level.Trace, "SSL: [T] '%s' certificate? %s", hostname, found);
     return found;
   }
 
@@ -96,7 +96,7 @@ version(SSL) {
     int err = SSL_get_error(ssl, retcode);
     switch (err) {
       case SSL_ERROR_NONE: break;
-      default: error("SSL_get_error %s %d", err, retcode); break;
+      default: error("SSL: SSL_get_error %s %d", err, retcode); break;
     }
     return(err);
   }
@@ -107,39 +107,39 @@ version(SSL) {
     for(size_t x = 0; x < hostname.length; x++) { ctx.hostname[x] = hostname[x]; }
     ctx.hostname[hostname.length] = '\0';
     ctx.context = createCTX(chainFile, keyFile);
-    if (ctx.context is null) { error("SSL: failed to create context for %s", hostname); return ctx; }
-    log(Level.Verbose, "context created for certificate: %s", fromStringz(ctx.hostname));
+    if (ctx.context is null) { error("SSL: Failed to create context for %s", hostname); return ctx; }
+    log(Level.Verbose, "SSL: [I] Context created, certificate: %s", fromStringz(ctx.hostname));
     SSL_CTX_callback_ctrl(ctx.context,SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, cast(ExternC!(void function())) &switchContext);
     return(ctx);
   }
 
-  // Reload all SSL contexts from certDir without restarting the server
-  void loadSSL(string certDir = ".ssl/", string sslKey = ".ssl/server.key") {
-    log(Level.Verbose, "loading Deimos.openSSL, certDir: %s, sslKey: %s", certDir, sslKey);
-    if (!exists(certDir) || !isDir(certDir)) { error("SSL cert dir '%s' not found", certDir); return; }
+  // Reload all SSL contexts from sslPath without restarting the server
+  void loadSSL(string sslPath = ".ssl/", string sslKey = ".ssl/server.key") {
+    log(Level.Verbose, "SSL: [I] loading sslPath: %s, sslKey: %s", sslPath, sslKey);
+    if (!exists(sslPath) || !isDir(sslPath)) { error("SSL: sslPath '%s' not found", sslPath); return; }
     if (!exists(sslKey) || !isFile(sslKey)) { sslKey.generateKey(); }
 
     SSLcontext[] localContexts;
-    foreach (DirEntry d; dirEntries(certDir, SpanMode.shallow)) {
+    foreach (DirEntry d; dirEntries(sslPath, SpanMode.shallow)) {
       if (d.name.endsWith(".chain")) {
         string hostname = baseName(d.name, ".chain");
         if (hostname.length < 255) {
           string chainFile = d.name;
-          log(Level.Verbose, "reloading certificate at: '%s'", chainFile);
+          log(Level.Verbose, "SSL: [I] Reloading certificate at: '%s'", chainFile);
           auto lc = loadContext(chainFile, hostname, sslKey);
           if (lc.context !is null) localContexts ~= lc;
         }
       }
     }
     contexts = localContexts;  // atomic single assignment
-    log(Level.Always, "(re)loaded %s SSL certificates", contexts.length);
+    log(Level.Always, "SSL: [I] Loaded %s SSL certificates", contexts.length);
   }
 
   // Close the server SSL socket, and clean up the different contexts
   void closeSSL(Socket socket) {
-    log(Level.Verbose, "closing server SSL socket");
+    log(Level.Verbose, "SSL: [I] Closing server SSL socket");
     socket.close();
-    log(Level.Verbose, "cleaning up %d HTTPS contexts", contexts.length);
+    log(Level.Verbose, "SSL: [I] Cleaning up %d SSL contexts", contexts.length);
     foreach (ref ctx; contexts) { SSL_CTX_free(ctx.context); }
     contexts = null;
   }

--- a/danode/statuscode.d
+++ b/danode/statuscode.d
@@ -2,6 +2,8 @@ module danode.statuscode;
 
 import danode.imports;
 
+import danode.log : tag, Level;
+
 struct StatusCodeT {
   size_t code;
   string reason;
@@ -64,9 +66,8 @@ enum StatusCode : StatusCodeT {
 };
 
 unittest {
-  import danode.log : custom;
-  custom(0, "FILE", "%s", __FILE__);
-  custom(0, "TEST", "statuscodes: %s", EnumMembers!StatusCode.length);
+  tag(Level.Always, "FILE", "%s", __FILE__);
+  tag(Level.Always, "TEST", "statuscodes: %s", EnumMembers!StatusCode.length);
   /*foreach (immutable v; EnumMembers!StatusCode) {
     custom(2, "TEST", "[%s] %s: \"%s\"", v.code, v, v.reason);
   }*/

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -4,7 +4,7 @@ import danode.imports;
 import danode.functions : has, from;
 import danode.files : FilePayload;
 import danode.request : Request;
-import danode.log : trace;
+import danode.log : log, error, Level;
 
 struct WebConfig {
   string[string]  data;
@@ -57,12 +57,12 @@ struct WebConfig {
 
   // Is the directory allowed to be viewed ?
   @property bool dirAllowed(in string localroot, in string path) const {
-    trace("dirAllowed: %s %s", localroot, path);
+    log(Level.Trace, "dirAllowed: %s %s", localroot, path);
     if (path.length <= localroot.length + 1) return true; // root dir always allowed
     string npath = path[(localroot.length + 1) .. $];
-    trace("npath: %s", npath);
+    log(Level.Trace, "npath: %s", npath);
     foreach (d; allowdirs) {
-      trace("%s in allowdirs: %s %s", npath, d, npath.indexOf(d));
+      log(Level.Trace, "%s in allowdirs: %s %s", npath, d, npath.indexOf(d));
       if (indexOf(strip(npath), strip(d)) == 0) return true;
     }
     return false;


### PR DESCRIPTION
Refactor logging, key generation, and process thread safety

- Replace Log class with module-level log functions (server, acme, request, error)
- Add generateKey() in ssl.d for server.key and account.key auto-generation on startup
- Add three separate log files: server.log, acme.log, request.log in logs/ dir
- Default log handles to stdout/stderr so unittests work without initLogs
- Fix ssl.d import of danode.server to break circular dependency in test builds