### PR TITLE
Development

### DIFF
--- a/danode/acme.d
+++ b/danode/acme.d
@@ -9,8 +9,8 @@ version(SSL) {
   import danode.log : log, error, Level;
   import danode.ssl : loadSSL, generateKey;
   import danode.functions : writeFile;
+  import danode.webconfig : serverConfig;
 
-  immutable string USER_EMAIL = "Danny.Arends@gmail.com";
   immutable string ACME_DIR_PROD = "https://acme-v02.api.letsencrypt.org/directory";
   immutable string ACME_DIR_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
 
@@ -90,7 +90,7 @@ version(SSL) {
           string chainPath = certDir ~ domain ~ ".chain";
 
           if (!exists(chainPath)) { log(Level.Always, "ACME: no chain found for %s, bootstrapping", domain);
-            if (renewCert(domain, USER_EMAIL, d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
+            if (renewCert(domain, serverConfig.get("user_email", ""), d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
             continue;
           }
 
@@ -106,7 +106,7 @@ version(SSL) {
 
           log(Level.Verbose, "ACME: chain %s expires in %d days", domain, days);
           if (days < 30) { log(Level.Verbose, "ACME: renewing chain for %s", domain);
-            if (renewCert(domain, USER_EMAIL, d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
+            if (renewCert(domain, serverConfig.get("user_email", ""), d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
           }
         }
       }

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -10,7 +10,8 @@ version(SSL) {
   import danode.ssl : loadSSL, generateKey;
   import danode.functions : writeFile;
 
-  immutable string ACME_DIR_PROD    = "https://acme-v02.api.letsencrypt.org/directory";
+  immutable string USER_EMAIL = "Danny.Arends@gmail.com";
+  immutable string ACME_DIR_PROD = "https://acme-v02.api.letsencrypt.org/directory";
   immutable string ACME_DIR_STAGING = "https://acme-staging-v02.api.letsencrypt.org/directory";
 
   __gshared string[string] acmeChallenges; // Shared challenge store: token -> keyAuthorization
@@ -89,7 +90,7 @@ version(SSL) {
           string chainPath = certDir ~ domain ~ ".chain";
 
           if (!exists(chainPath)) { log(Level.Always, "ACME: no chain found for %s, bootstrapping", domain);
-            if (renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
+            if (renewCert(domain, USER_EMAIL, d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
             continue;
           }
 
@@ -105,7 +106,7 @@ version(SSL) {
 
           log(Level.Verbose, "ACME: chain %s expires in %d days", domain, days);
           if (days < 30) { log(Level.Verbose, "ACME: renewing chain for %s", domain);
-            if (renewCert(domain, "Danny.Arends@gmail.com", d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
+            if (renewCert(domain, USER_EMAIL, d.name, chainPath, accountKey, staging)) { loadSSL(certDir, keyFile); }
           }
         }
       }

--- a/danode/acme.d
+++ b/danode/acme.d
@@ -8,7 +8,7 @@ version(SSL) {
 
   import danode.log : log, error, Level;
   import danode.ssl : loadSSL, generateKey;
-  import danode.functions : writeFile;
+  import danode.functions : writeFile, isFILE;
   import danode.webconfig : serverConfig;
 
   immutable string ACME_DIR_PROD = "https://acme-v02.api.letsencrypt.org/directory";
@@ -80,7 +80,7 @@ version(SSL) {
 
     // Check cert expiry and renew if < 30 days remaining
   void checkAndRenew(string certDir = ".ssl/", string keyFile = ".ssl/server.key", string accountKey = ".ssl/account.key", bool staging = false) {
-    if (!exists(accountKey) || !isFile(accountKey)) { accountKey.generateKey(); }
+    if (!isFILE(accountKey)) { accountKey.generateKey(); }
     new Thread({
       try {
         log(Level.Always, "checkAndRenew called on '%s' with key '%s'", certDir, accountKey);

--- a/danode/cgi.d
+++ b/danode/cgi.d
@@ -18,9 +18,9 @@ class CGI : Payload {
   public:
     string command;
 
-    this(string[] command, string path, string[string] environ, bool removeInput = true, long maxtime = 4500){
+    this(string[] command, string path, string[string] environ, bool removeInput = true){
       this.command = command.join(" ");
-      external = new Process(command, path, environ, removeInput, maxtime); 
+      external = new Process(command, path, environ, removeInput);
       external.start();
     }
 

--- a/danode/client.d
+++ b/danode/client.d
@@ -63,7 +63,7 @@ class Client {
           }
           if (response.ready && response.completed) {       // We've completed the request, response cycle
             driver.requests++;
-            if(response.keepalive) { logRR(request, response); }
+            if(response.keepalive) { logConnection(request, response); }
             request.clearUploadFiles();                     // Clean uploaded files
             driver.inbuffer.clear();                        // Clear the input buffer
             if(!response.keepalive){ stop(); continue; }    // No keep alive, then stop this client
@@ -77,14 +77,14 @@ class Client {
           }
           log(Level.Trace, "Connection %s:%s (%s msecs) %s", ip, port, starttime, to!string(driver.inbuffer.data));
         }
-        logRR(request, response);
+        logConnection(request, response);
       } catch(Exception e) { log(Level.Verbose, "Unknown Client Exception: %s", e); stop();
       } catch(Error e) { log(Level.Verbose, "Unknown Client Error: %s", e); stop(); }
       log(Level.Verbose, "Connection %s:%s (%s) closed. %d requests %s (%s msecs)", ip, port, (driver.isSecure() ? "SSL" : "HTTP"), 
                                                                                       driver.requests, driver.senddata, starttime);
     }
 
-    void logRR(in Request rq, in Response rs) {
+    void logConnection(in Request rq, in Response rs) {
       string uri;
       try { uri = decodeComponent(rq.uri); } catch (Exception e) { uri = rq.uri; }
       long bytes = (rs.payload && rs.isRange) ? (rs.rangeEnd - rs.rangeStart + 1) : (rs.payload ? rs.payload.length : 0);

--- a/danode/client.d
+++ b/danode/client.d
@@ -11,11 +11,7 @@ import danode.router : Router, runRequest;
 import danode.response : Response;
 import danode.request : Request;
 import danode.log : log, tag, Level;
-
-immutable size_t MAX_HEADER_SIZE  = 1024 * 32;          ///  32KB Header
-immutable size_t MAX_REQUEST_SIZE = 1024 * 1024 * 2;    ///   2MB Body
-immutable size_t MAX_UPLOAD_SIZE  = 1024 * 1024 * 100;  /// 100MB Multipart uploads
-immutable size_t MAX_SSE_TIME = 60_000;                 /// 60 seconds max SSE lifetime
+import danode.webconfig : serverConfig;
 
 class Client {
   private:
@@ -42,13 +38,16 @@ class Client {
           request.clearUploadFiles();                           // Clean uploaded files
           response.kill();                                      // kill any running CGI process
         }
+        size_t headerLimit  = serverConfig.get("max_header_size", 32 * 1024);
+        size_t uploadLimit  = serverConfig.get("max_upload_size",  100 * 1024 * 1024);
+        size_t requestLimit = serverConfig.get("max_request_size", 2   * 1024 * 1024);
         while (running) {
           if (driver.receive(driver.socket) > 0) { // We've received new data
             if (!driver.hasHeader()) {
-              if (driver.inbuffer.data.length > MAX_HEADER_SIZE) { driver.sendHeaderTooLarge(response); stop(); continue; }
+              if (driver.inbuffer.data.length > headerLimit) { driver.sendHeaderTooLarge(response); stop(); continue; }
             } else {
-              if (driver.endOfHeader > MAX_HEADER_SIZE) { driver.sendHeaderTooLarge(response); stop(); continue; }
-              size_t limit = (driver.header.indexOf("multipart/") >= 0) ? MAX_UPLOAD_SIZE : MAX_REQUEST_SIZE;
+              if (driver.endOfHeader > headerLimit) { driver.sendHeaderTooLarge(response); stop(); continue; }
+              size_t limit = (driver.header.indexOf("multipart/") >= 0)? uploadLimit: requestLimit;
               if (driver.inbuffer.data.length > limit) { driver.sendPayloadTooLarge(response); stop(); continue; }
             }
             // Parse the data and try to create a response (Could fail multiple times)
@@ -58,7 +57,7 @@ class Client {
             driver.send(response, driver.socket);           // Send the response, hit multiple times, send what you can and return
             if (response.isSSE) {
               if (response.scriptCompleted) { response.completed = true; stop(); continue; }
-              if (starttime >= MAX_SSE_TIME) { log(Level.Verbose, "SSE max lifetime reached"); stop(); continue; }
+              if (starttime >= serverConfig.get("max_sse_time", 60_000)) { log(Level.Verbose, "SSE max lifetime reached"); stop(); continue; }
             }
           }
           if (response.ready && response.completed) {       // We've completed the request, response cycle

--- a/danode/client.d
+++ b/danode/client.d
@@ -51,7 +51,7 @@ class Client {
               if (driver.inbuffer.data.length > limit) { driver.sendPayloadTooLarge(response); stop(); continue; }
             }
             // Parse the data and try to create a response (Could fail multiple times)
-            if (!response.ready) { router.route(driver, request, response, maxtime); }
+            if (!response.ready) { router.route(driver, request, response); }
           }
           if (response.ready && !response.completed) {      // We know what to respond, but haven't send all of it yet
             driver.send(response, driver.socket);           // Send the response, hit multiple times, send what you can and return

--- a/danode/client.d
+++ b/danode/client.d
@@ -4,20 +4,18 @@ module danode.client;
 
 import danode.imports;
 
-import danode.cgi : CGI;
 import danode.statuscode : StatusCode;
 import danode.functions: htmltime, Msecs;
-import danode.interfaces : DriverInterface, ClientInterface, StringDriver;
+import danode.interfaces : DriverInterface, ClientInterface, StringDriver, sendHeaderTooLarge, sendPayloadTooLarge, sendTimedOut;
 import danode.router : Router, runRequest;
-import danode.response : Response, setPayload;
+import danode.response : Response;
 import danode.request : Request;
-import danode.payload : PayloadType;
 import danode.log : log, tag, Level;
 
-immutable size_t MAX_HEADER_SIZE  = 1024 * 32;          //  32KB Header
-immutable size_t MAX_REQUEST_SIZE = 1024 * 1024 * 2;    //   2MB Body
-immutable size_t MAX_UPLOAD_SIZE  = 1024 * 1024 * 100;  // 100MB Multipart uploads
-immutable size_t MAX_SSE_TIME = 60_000;                 // 60 seconds max SSE lifetime
+immutable size_t MAX_HEADER_SIZE  = 1024 * 32;          ///  32KB Header
+immutable size_t MAX_REQUEST_SIZE = 1024 * 1024 * 2;    ///   2MB Body
+immutable size_t MAX_UPLOAD_SIZE  = 1024 * 1024 * 100;  /// 100MB Multipart uploads
+immutable size_t MAX_SSE_TIME = 60_000;                 /// 60 seconds max SSE lifetime
 
 class Client : ClientInterface {
   private:
@@ -28,7 +26,6 @@ class Client : ClientInterface {
 
   public:
     this(Router router, DriverInterface driver, long maxtime = 5000) {
-      log(Level.Trace, "client constructor");
       this.router = router;
       this.driver = driver;
       this.maxtime = maxtime;
@@ -37,7 +34,7 @@ class Client : ClientInterface {
    final void run() {
       log(Level.Trace, "New connection established %s:%d", ip(), port() );
       try {
-        if (driver.openConnection() == false) { log(Level.Verbose, "WARN: Unable to open connection"); stop(); }
+        if (!driver.openConnection()) { log(Level.Verbose, "WARN: Unable to open connection"); return; }
         Request request;
         Response response;
         scope (exit) {
@@ -48,11 +45,11 @@ class Client : ClientInterface {
         while (running) {
           if (driver.receive(driver.socket) > 0) { // We've received new data
             if (!driver.hasHeader()) {
-              if (driver.inbuffer.data.length > MAX_HEADER_SIZE) { driver.setHeaderTooLarge(response); stop(); continue; }
+              if (driver.inbuffer.data.length > MAX_HEADER_SIZE) { driver.sendHeaderTooLarge(response); stop(); continue; }
             } else {
-              if (driver.endOfHeader > MAX_HEADER_SIZE) { driver.setHeaderTooLarge(response); stop(); continue; }
+              if (driver.endOfHeader > MAX_HEADER_SIZE) { driver.sendHeaderTooLarge(response); stop(); continue; }
               size_t limit = (driver.header.indexOf("multipart/") >= 0) ? MAX_UPLOAD_SIZE : MAX_REQUEST_SIZE;
-              if (driver.inbuffer.data.length > limit) { driver.setPayloadTooLarge(response); stop(); continue; }
+              if (driver.inbuffer.data.length > limit) { driver.sendPayloadTooLarge(response); stop(); continue; }
             }
             // Parse the data and try to create a response (Could fail multiple times)
             if (!response.ready) { router.route(driver, request, response, maxtime); }
@@ -75,7 +72,7 @@ class Client : ClientInterface {
           }
           if (lastmodified >= maxtime) { // Client are not allowed to be silent for more than maxtime
             log(Level.Trace, "inactivity: %s > %s", lastmodified, maxtime);
-            driver.setTimedOut(response);
+            driver.sendTimedOut(response);
             stop(); continue;
           }
           log(Level.Trace, "Connection %s:%s (%s msecs) %s", ip, port, starttime, to!string(driver.inbuffer.data));
@@ -96,15 +93,10 @@ class Client : ClientInterface {
       atomicStore(terminated, true);
     }
 
-    // Number of requests served
     final @property long requests() const { return(driver ? driver.requests : 0); }
-    // Start time of the client in mseconds (stored in the connection driver)
     final @property long starttime() const { return(driver.starttime); }
-    // When was the client last modified in mseconds (stored in the connection driver)
     final @property long lastmodified() const { return(driver.lastmodified); }
-    // Port of the client
     final @property long port() const { return(driver.port()); } 
-    // ip address of the client
     final @property string ip() const { return(driver.ip()); } 
 }
 
@@ -116,25 +108,6 @@ void log(in ClientInterface cl, in Request rq, in Response rs) {
   long ms = rq.starttime == SysTime.init ? -1 : Msecs(rq.starttime);
   tag(Level.Always, format("%d", code),
       "%s %s:%s %s%s [%d] %.1fkb in %s ms ", htmltime(), cl.ip, cl.port, rq.shorthost, uri.replace("%", "%%"), cl.requests, bytes/1024f, ms);
-}
-
-// serve a 408 connection timed out page
-void setTimedOut(ref DriverInterface driver, ref Response response) {
-  if(response.payload && response.payload.type == PayloadType.Script){ to!CGI(response.payload).notifyovertime(); }
-  response.setPayload(StatusCode.TimedOut, "408 - Connection Timed Out\n", "text/plain");
-  driver.send(response, driver.socket);
-}
-
-// serve a 431 request header fields too large page
-void setHeaderTooLarge(ref DriverInterface driver, ref Response response) {
-  response.setPayload(StatusCode.HeaderFieldsTooLarge, "431 - Request Header Fields Too Large\n", "text/plain");
-  driver.send(response, driver.socket);
-}
-
-// serve a 413 payload too large page
-void setPayloadTooLarge(ref DriverInterface driver, ref Response response) {
-  response.setPayload(StatusCode.PayloadTooLarge, "413 - Payload Too Large\n", "text/plain");
-  driver.send(response, driver.socket);
 }
 
 unittest {

--- a/danode/client.d
+++ b/danode/client.d
@@ -6,7 +6,7 @@ import danode.imports;
 
 import danode.statuscode : StatusCode;
 import danode.functions: htmltime, Msecs;
-import danode.interfaces : DriverInterface, ClientInterface, StringDriver, sendHeaderTooLarge, sendPayloadTooLarge, sendTimedOut;
+import danode.interfaces : DriverInterface, StringDriver, sendHeaderTooLarge, sendPayloadTooLarge, sendTimedOut;
 import danode.router : Router, runRequest;
 import danode.response : Response;
 import danode.request : Request;
@@ -17,7 +17,7 @@ immutable size_t MAX_REQUEST_SIZE = 1024 * 1024 * 2;    ///   2MB Body
 immutable size_t MAX_UPLOAD_SIZE  = 1024 * 1024 * 100;  /// 100MB Multipart uploads
 immutable size_t MAX_SSE_TIME = 60_000;                 /// 60 seconds max SSE lifetime
 
-class Client : ClientInterface {
+class Client {
   private:
     Router              router;              /// Router class from server
     DriverInterface     driver;              /// Driver
@@ -63,7 +63,7 @@ class Client : ClientInterface {
           }
           if (response.ready && response.completed) {       // We've completed the request, response cycle
             driver.requests++;
-            if(response.keepalive) { this.log(request, response); }
+            if(response.keepalive) { logRR(request, response); }
             request.clearUploadFiles();                     // Clean uploaded files
             driver.inbuffer.clear();                        // Clear the input buffer
             if(!response.keepalive){ stop(); continue; }    // No keep alive, then stop this client
@@ -77,11 +77,21 @@ class Client : ClientInterface {
           }
           log(Level.Trace, "Connection %s:%s (%s msecs) %s", ip, port, starttime, to!string(driver.inbuffer.data));
         }
-        this.log(request, response);
+        logRR(request, response);
       } catch(Exception e) { log(Level.Verbose, "Unknown Client Exception: %s", e); stop();
       } catch(Error e) { log(Level.Verbose, "Unknown Client Error: %s", e); stop(); }
       log(Level.Verbose, "Connection %s:%s (%s) closed. %d requests %s (%s msecs)", ip, port, (driver.isSecure() ? "SSL" : "HTTP"), 
                                                                                       driver.requests, driver.senddata, starttime);
+    }
+
+    void logRR(in Request rq, in Response rs) {
+      string uri;
+      try { uri = decodeComponent(rq.uri); } catch (Exception e) { uri = rq.uri; }
+      long bytes = (rs.payload && rs.isRange) ? (rs.rangeEnd - rs.rangeStart + 1) : (rs.payload ? rs.payload.length : 0);
+      int code = cast(int)(rs.payload ? rs.statuscode.code : 0);
+      long ms = rq.starttime == SysTime.init ? -1 : Msecs(rq.starttime);
+      tag(Level.Always, format("%d", code),
+          "%s %s:%s %s%s [%d] %.1fkb in %s ms ", htmltime(), ip, port, rq.shorthost, uri.replace("%", "%%"), requests, bytes/1024f, ms);
     }
 
     // Is the client still running, if the socket was gone it's not otherwise check the terminated flag
@@ -98,16 +108,6 @@ class Client : ClientInterface {
     final @property long lastmodified() const { return(driver.lastmodified); }
     final @property long port() const { return(driver.port()); } 
     final @property string ip() const { return(driver.ip()); } 
-}
-
-void log(in ClientInterface cl, in Request rq, in Response rs) {
-  string uri;
-  try { uri = decodeComponent(rq.uri); } catch (Exception e) { uri = rq.uri; }
-  long bytes = (rs.payload && rs.isRange) ? (rs.rangeEnd - rs.rangeStart + 1) : (rs.payload ? rs.payload.length : 0);
-  int code = cast(int)(rs.payload ? rs.statuscode.code : 0);
-  long ms = rq.starttime == SysTime.init ? -1 : Msecs(rq.starttime);
-  tag(Level.Always, format("%d", code),
-      "%s %s:%s %s%s [%d] %.1fkb in %s ms ", htmltime(), cl.ip, cl.port, rq.shorthost, uri.replace("%", "%%"), cl.requests, bytes/1024f, ms);
 }
 
 unittest {

--- a/danode/client.d
+++ b/danode/client.d
@@ -19,7 +19,6 @@ immutable size_t MAX_REQUEST_SIZE = 1024 * 1024 * 2;    //   2MB Body
 immutable size_t MAX_UPLOAD_SIZE  = 1024 * 1024 * 100;  // 100MB Multipart uploads
 immutable size_t MAX_SSE_TIME = 60_000;                 // 60 seconds max SSE lifetime
 
-
 class Client : ClientInterface {
   private:
     Router              router;              /// Router class from server
@@ -93,7 +92,7 @@ class Client : ClientInterface {
 
     // Stop the client by setting the terminated flag
     final @property void stop() {
-      log(Level.Trace, "connection %s:%s stop called", ip, port);
+      log(Level.Trace, "Connection %s:%s stop called", ip, port);
       atomicStore(terminated, true);
     }
 

--- a/danode/client.d
+++ b/danode/client.d
@@ -1,4 +1,4 @@
-/** danode/client.d - Per-connection thread: request/response lifecycle, keep-alive, timeouts
+/** danode/client.d - Per-connection handler: request/response lifecycle, keep-alive, timeouts
   * License: GPLv3 (https://github.com/DannyArends/DaNode) - Danny Arends **/
 module danode.client;
 
@@ -20,7 +20,7 @@ immutable size_t MAX_UPLOAD_SIZE  = 1024 * 1024 * 100;  // 100MB Multipart uploa
 immutable size_t MAX_SSE_TIME = 60_000;                 // 60 seconds max SSE lifetime
 
 
-class Client : Thread, ClientInterface {
+class Client : ClientInterface {
   private:
     Router              router;              /// Router class from server
     DriverInterface     driver;              /// Driver
@@ -33,7 +33,6 @@ class Client : Thread, ClientInterface {
       this.router = router;
       this.driver = driver;
       this.maxtime = maxtime;
-      super(&run); // initialize the thread
     }
 
    final void run() {
@@ -85,7 +84,6 @@ class Client : Thread, ClientInterface {
         this.log(request, response);
       } catch(Exception e) { log(Level.Verbose, "Unknown Client Exception: %s", e); stop();
       } catch(Error e) { log(Level.Verbose, "Unknown Client Error: %s", e); stop(); }
-
       log(Level.Verbose, "Connection %s:%s (%s) closed. %d requests %s (%s msecs)", ip, port, (driver.isSecure() ? "SSL" : "HTTP"), 
                                                                                       driver.requests, driver.senddata, starttime);
     }

--- a/danode/client.d
+++ b/danode/client.d
@@ -88,7 +88,7 @@ class Client : ClientInterface {
     final @property bool running() const { return(!atomicLoad(terminated) && driver.socketReady()); }
 
     // Stop the client by setting the terminated flag
-    final @property void stop() {
+    final void stop() {
       log(Level.Trace, "Connection %s:%s stop called", ip, port);
       atomicStore(terminated, true);
     }

--- a/danode/files.d
+++ b/danode/files.d
@@ -106,40 +106,6 @@ class FilePayload : Payload {
       return(buffered = true);
     } }
 
-    /* Whole file content served via the bytes function */
-    final @property string content(){ return( to!string(bytes(0, length)) ); }
-    /* Is the file a real file (i.e. does it exist on disk) */
-    final @property bool realfile() const { return(path.exists()); }
-    /* Do we have a gzip encoded version */
-    final @property bool hasEncodedVersion() const { return(encbuf !is null); }
-    /* Is the file defined as static in mimetypes.d ? */
-    final @property bool isStaticFile() { return(!path.isCGI()); }
-    /* Time the file was last modified ? */
-    final @property SysTime mtime() const { if(!realfile){ return btime; } return path.timeLastModified(); }
-    /* Files are always assumed ready to be handled (unlike Common Gate Way threads)  */
-    final @property long ready() { return(true); }
-    /* Payload type delivered to the client  */
-    final @property PayloadType type() const { return(PayloadType.File); }
-    /* Size of the file, -1 if it does not exist  */
-    final @property ptrdiff_t fileSize() const { if(!realfile){ return -1; } return to!ptrdiff_t(path.getSize()); }
-    /* Length of the buffer  */
-    final @property long buffersize() const { return cast(long)(buf.length); }
-    /* Mimetype of the file  */
-    final @property string mimetype() const { return mime(path); }
-    /* Buffer status of the file  */
-    final @property bool isBuffered() const { return buffered; }
-    /* Path of the file  */
-    final @property string filePath() const { return path; }
-    /* Status code for file is StatusCode.Ok ? */
-    final @property StatusCode statuscode() const { 
-      return realfile ? StatusCode.Ok : StatusCode.NotFound; 
-    }
-    /* Get the number of bytes that the client response has, based on encoding */
-    final @property ptrdiff_t length() const {
-      if(hasEncodedVersion && gzip) return(encbuf.length);
-      return(fileSize());
-    }
-
     /* Get bytes in a lockfree manner from the correct underlying buffer */
     final const(char)[] bytes(ptrdiff_t from, ptrdiff_t maxsize = 4096, bool isRange = false, long start = 0, long end = -1) { synchronized {
       if (!realfile) { return []; }
@@ -154,6 +120,21 @@ class FilePayload : Payload {
       log(Level.Verbose, "FilePayload.bytes() called on unbuffered file '%s', this should not happen", path);
       return([]);
     } }
+
+    final @property string content(){ return( to!string(bytes(0, length)) ); }
+    final @property bool realfile() const { return(path.exists()); }
+    final @property bool hasEncodedVersion() const { return(encbuf !is null); }
+    final @property bool isStaticFile() { return(!path.isCGI()); }
+    final @property SysTime mtime() const { try { return path.timeLastModified(); }catch (Exception e) { return btime; } }
+    final @property long ready() { return(true); }
+    final @property PayloadType type() const { return(PayloadType.File); }
+    final @property ptrdiff_t fileSize() const { if(!realfile){ return -1; } return to!ptrdiff_t(path.getSize()); }
+    final @property long buffersize() const { return cast(long)(buf.length); }
+    final @property string mimetype() const { return mime(path); }
+    final @property bool isBuffered() const { return buffered; }
+    final @property string filePath() const { return path; }
+    final @property StatusCode statuscode() const { return realfile ? StatusCode.Ok : StatusCode.NotFound; }
+    final @property ptrdiff_t length() const { if(hasEncodedVersion && gzip) { return(encbuf.length); } return(fileSize()); }
 }
 
 // Compute the Range

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -65,7 +65,7 @@ class FileSystem {
       // Remove files that no longer exist on disk
       foreach (k; domain.files.keys) { if (!exists(dname ~ k)) { domain.files.remove(k); } }
 
-      log(Level.Always, "Domain: '%s' files %s|%s", dname, domain.buffered, domain.entries);
+      log(Level.Verbose, "Domain: '%s' files %s|%s", dname, domain.buffered, domain.entries);
       log(Level.Verbose, "Domain: '%s' size %.2f/%.2f kB", dname, domain.buffersize / 1024.0, domain.size / 1024.0);
       return(domain);
     } }

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -65,7 +65,7 @@ class FileSystem {
       // Remove files that no longer exist on disk
       foreach (k; domain.files.keys) { if (!exists(dname ~ k)) { domain.files.remove(k); } }
 
-      log(Level.Verbose, "Domain: '%s' files %s|%s", dname, domain.buffered, domain.entries);
+      log(Level.Always, "Domain: '%s' files %s|%s", dname, domain.buffered, domain.entries);
       log(Level.Verbose, "Domain: '%s' size %.2f/%.2f kB", dname, domain.buffersize / 1024.0, domain.size / 1024.0);
       return(domain);
     } }

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -7,7 +7,7 @@ import danode.imports;
 import danode.statuscode : StatusCode;
 import danode.payload : PayloadType;
 import danode.files : FilePayload, FileStream;
-import danode.functions : has;
+import danode.functions : has, isFILE;
 import danode.log : log, tag, error, Level;
 
 /* Domain name structure containing files in that domain
@@ -50,18 +50,20 @@ class FileSystem {
     /* Scan a single folder */
     final Domain scan(string dname){ synchronized {
       Domain domain;
-      foreach (DirEntry f; dirEntries(dname, SpanMode.depth)) {
-        if (f.isFile()) {
-          string shortname = replace(f.name[dname.length .. $], "\\", "/");
-          if (shortname.endsWith(".in") || shortname.endsWith(".up")) continue;
-          log(Level.Trace, "File: '%s' as '%s'", f.name, shortname);
-          if (!domain.files.has(shortname)) {
-            domain.files[shortname] = new FilePayload(f.name, maxsize);
-            domain.entries++;
-            if(domain.files[shortname].buffer()) { domain.buffered++; }
+      try {
+        foreach (DirEntry f; dirEntries(dname, SpanMode.depth)) {
+          if (f.isFILE()) {
+            string shortname = replace(f.name[dname.length .. $], "\\", "/");
+            if (shortname.endsWith(".in") || shortname.endsWith(".up")) continue;
+            log(Level.Trace, "File: '%s' as '%s'", f.name, shortname);
+            if (!domain.files.has(shortname)) {
+              domain.files[shortname] = new FilePayload(f.name, maxsize);
+              domain.entries++;
+              if(domain.files[shortname].buffer()) { domain.buffered++; }
+            }
           }
         }
-      }
+      } catch (Exception e) { log(Level.Trace, "scan: directory iteration interrupted: %s", e.msg); }
       // Remove files that no longer exist on disk
       foreach (k; domain.files.keys) { if (!exists(dname ~ k)) { domain.files.remove(k); } }
 

--- a/danode/filesystem.d
+++ b/danode/filesystem.d
@@ -7,7 +7,7 @@ import danode.imports;
 import danode.statuscode : StatusCode;
 import danode.payload : PayloadType;
 import danode.files : FilePayload, FileStream;
-import danode.functions : has, isFILE;
+import danode.functions : has, isFILE, isDIR;
 import danode.log : log, tag, error, Level;
 
 /* Domain name structure containing files in that domain
@@ -40,7 +40,7 @@ class FileSystem {
 
     /* Scan the whole filesystem for changes */
     final void scan(){ synchronized {
-      foreach (DirEntry d; dirEntries(root, SpanMode.shallow)){ if(d.isDir()){
+      foreach (DirEntry d; dirEntries(root, SpanMode.shallow)){ if(d.name.isDIR()){
         domains[d.name] = scan(d.name);
       } }
       // Remove domains that no longer exist on disk

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -210,6 +210,7 @@ unittest {
   assert(safePath("www/localhost", "/\0etc/passwd") is null, "null byte must be blocked");
   assert(safePath("www/localhost", "/test.txt") !is null, "valid path must be allowed");
   assert(safePath("www/localhost", "/test/1.txt") !is null, "valid subpath must be allowed");
+  assert(safePath("www/localhost", "/nonexistent.txt") !is null, "non-existent valid path must be allowed");
 
   // htmlEscape - XSS critical
   assert(htmlEscape("<script>") == "&lt;script&gt;", "< and > must be escaped");

--- a/danode/functions.d
+++ b/danode/functions.d
@@ -49,11 +49,14 @@ string safePath(in string root, in string path) {
   if (path.canFind("\0")) return null;
   string full = root ~ (path.startsWith("/") ? path : "/" ~ path);
   try {
+    string absroot = root.resolve();
+    if (!absroot.endsWith("/")) absroot ~= "/";
     if (exists(full)) {
       string resolved = full.resolve();
-      string absroot = root.resolve();
-      if (!absroot.endsWith("/")) absroot ~= "/";
       if (resolved != absroot[0..$-1] && !resolved.startsWith(absroot)) return null;
+    } else {
+      string parent = dirName(full).resolve();
+      if (parent != absroot[0..$-1] && !parent.startsWith(absroot)) return null;
     }
   } catch (Exception e) { return null; }
   return full;

--- a/danode/https.d
+++ b/danode/https.d
@@ -10,9 +10,8 @@ version(SSL) {
   import danode.response : Response;
   import danode.log : tag, log, error, Level;
   import danode.interfaces : DriverInterface;
-  import danode.ssl;
-
-  immutable long HANDSHAKE_TIMEOUT = 5000;  // 5 seconds
+  import danode.ssl : checkForError, contexts;
+  import danode.webconfig : serverConfig;
 
   class HTTPS : DriverInterface {
     private:
@@ -26,7 +25,7 @@ version(SSL) {
       bool performHandshake() {
         log(Level.Trace, "Performing handshake");
         int rA, rE;
-        while (starttime < HANDSHAKE_TIMEOUT) {
+        while (starttime < serverConfig.get("handshake_timeout", 5000L)) {
           rA = SSL_accept(ssl);
           if (rA == 1) return(true);    // Success
           if (rA == 0) return(false);   // Controlled failure: Not retryable

--- a/danode/imports.d
+++ b/danode/imports.d
@@ -8,7 +8,6 @@ public import core.stdc.stdio : fileno;
 
 // Public imported structures and enums from core
 public import core.atomic;
-public import core.memory : GC;
 public import core.sync.semaphore : Semaphore;
 public import core.sync.mutex : Mutex;
 public import core.thread;

--- a/danode/imports.d
+++ b/danode/imports.d
@@ -8,6 +8,8 @@ public import core.stdc.stdio : fileno;
 
 // Public imported structures and enums from core
 public import core.atomic;
+public import core.memory : GC;
+public import core.sync.semaphore : Semaphore;
 public import core.sync.mutex : Mutex;
 public import core.thread;
 

--- a/danode/interfaces.d
+++ b/danode/interfaces.d
@@ -11,26 +11,12 @@ import danode.response : Response, setPayload;
 import danode.statuscode : StatusCode;
 import danode.log : log, error, Level;
 
-/* Client interface used by the server */
-interface ClientInterface {
-  @property bool    running();          /// Is the client still handling requests
-  @property long    starttime();        /// When was the client last started
-  @property long    lastmodified();     /// When was the client last modified
-  @property void    stop();             /// Stop the client
-
-  @property long requests() const;      /// Number of requests served
-  @property string  ip() const;         /// IP location of the client
-  @property long    port() const;       /// Port at which the client is connected
-
-  void run();                           /// Main client loop and logic
-}
-
 /* Connection/Driver interface available to the client */
 abstract class DriverInterface {
   public:
     Appender!(char[])   inbuffer;            /// Input appender buffer
     Socket              socket;              /// Client socket for reading and writing
-    SocketSet           socketSet;
+    SocketSet           socketSet;           /// SocketSet used for non-blocking select on this connection
     long                requests = 0;        /// Number of requests we handled
     long[long]          senddata;            /// Size of data send per request
     SysTime             systime;             /// Time in ms since this process came alive

--- a/danode/interfaces.d
+++ b/danode/interfaces.d
@@ -3,8 +3,11 @@
 module danode.interfaces;
 
 import danode.imports;
+
+import danode.cgi : CGI;
 import danode.functions : Msecs, sISelect, bodystart, endofheader, fullheader;
-import danode.response : Response;
+import danode.payload : PayloadType;
+import danode.response : Response, setPayload;
 import danode.statuscode : StatusCode;
 import danode.log : log, error, Level;
 
@@ -62,32 +65,17 @@ abstract class DriverInterface {
     }
 
     long receiveData(ref char[] buffer);
-    bool openConnection(); /// Open the connection
-    void closeConnection(); /// Close the connection
-    @nogc bool isSecure() const nothrow; /// Are we secure ?
+    bool openConnection();
+    void closeConnection();
+    @nogc bool isSecure() const nothrow;
 
     // Send upto maxsize bytes from the response to the client
     void send(ref Response response, Socket conn, ptrdiff_t maxsize = 4096);
 
-    // port being used for communication
-    final @property long port() const { 
-      if (address !is null) return(to!long(address.toPortString())); 
-      return(-1); 
-    }
-
-    // IP address connected to
-    final @property string ip() const {
-      if (address !is null) return(address.toAddrString());
-      return("0.0.0.0"); 
-    }
-
-    // Milliseconds since start of connection
+    final @property long port() const { if (address !is null){ return(to!long(address.toPortString())); } return(-1); }
+    final @property string ip() const { if (address !is null){ return(address.toAddrString()); } return("0.0.0.0"); }
     final @property long starttime() const { return(Msecs(systime)); }
-
-    // Milliseconds since last modified
     final @property long lastmodified() const { return(Msecs(modtime)); }
-
-    // Byte input converted to header as string
     final @property string header() const { return(fullheader(inbuffer.data)); }
 
     // Byte input converted to body as string
@@ -96,14 +84,28 @@ abstract class DriverInterface {
       return(to!string(inbuffer.data[bodyStart() .. $]));
     }
 
-    // Where does the HTTP request header end ?
     final @property ptrdiff_t endOfHeader() const { return(endofheader(inbuffer.data)); }
-
-    // Where does the HTTP request body begin ?
     final @property ptrdiff_t bodyStart() const { return(bodystart(inbuffer.data)); }
-
-    // Do we have a header separator ? "\r\n\r\n" or "\n\n"
     final @property bool hasHeader() const { return(endOfHeader > 0); }
+}
+
+// serve a 408 connection timed out page
+void sendTimedOut(ref DriverInterface driver, ref Response response) {
+  if(response.payload && response.payload.type == PayloadType.Script){ to!CGI(response.payload).notifyovertime(); }
+  response.setPayload(StatusCode.TimedOut, "408 - Connection Timed Out\n", "text/plain");
+  driver.send(response, driver.socket);
+}
+
+// serve a 431 request header fields too large page
+void sendHeaderTooLarge(ref DriverInterface driver, ref Response response) {
+  response.setPayload(StatusCode.HeaderFieldsTooLarge, "431 - Request Header Fields Too Large\n", "text/plain");
+  driver.send(response, driver.socket);
+}
+
+// serve a 413 payload too large page
+void sendPayloadTooLarge(ref DriverInterface driver, ref Response response) {
+  response.setPayload(StatusCode.PayloadTooLarge, "413 - Payload Too Large\n", "text/plain");
+  driver.send(response, driver.socket);
 }
 
 class StringDriver : DriverInterface {

--- a/danode/post.d
+++ b/danode/post.d
@@ -8,7 +8,7 @@ import danode.cgi : CGI;
 import danode.statuscode : StatusCode;
 import danode.interfaces : StringDriver;
 import danode.request : Request, RequestMethod;
-import danode.response : SERVERINFO, Response, setPayload;
+import danode.response : Response, setPayload;
 import danode.webconfig : WebConfig;
 import danode.mimetypes : mime;
 import danode.filesystem : FileSystem;
@@ -146,7 +146,7 @@ final void serverAPI(in FileSystem filesystem, in WebConfig config, in Request r
 
   // Give HTTP_COOKIES to CGI
   foreach (c; request.cookies.split("; ")) { content.put(format("C=%s\n", chomp(c)) ); }
-  content.put(format("S=SERVER_SOFTWARE=%s\n", SERVERINFO));
+  content.put(format("S=SERVER_SOFTWARE=%s\n", serverConfig.get("serverinfo", "DaNode/0.0.3")));
   try{
     content.put(format("S=SERVER_NAME=%s\n", (response.address)? response.address.toHostNameString() : "localhost"));
   }catch(Exception e){

--- a/danode/post.d
+++ b/danode/post.d
@@ -5,7 +5,6 @@ module danode.post;
 import danode.imports;
 
 import danode.cgi : CGI;
-import danode.client : MAX_REQUEST_SIZE;
 import danode.statuscode : StatusCode;
 import danode.interfaces : StringDriver;
 import danode.request : Request, RequestMethod;
@@ -15,6 +14,7 @@ import danode.mimetypes : mime;
 import danode.filesystem : FileSystem;
 import danode.functions : from, writeFile, parseQueryString;
 import danode.log : log, tag, error, Level;
+import danode.webconfig : serverConfig;
 
 immutable string      MPHEADER         = "multipart/form-data";                     /// Multipart header id
 immutable string      XFORMHEADER      = "application/x-www-form-urlencoded";       /// X-form header id
@@ -46,7 +46,7 @@ final bool parsePost(ref Request request, ref Response response, in FileSystem f
   if (expectedlength == 0) {
     log(Level.Trace, "Post: [T] Content-Length not specified (or 0), length: %s", content.length);
     return(response.havepost = true); // When we don't receive any post data it is meaningless to scan for any content
-  } else if (expectedlength > MAX_REQUEST_SIZE) {
+  } else if (expectedlength > serverConfig.get("max_request_size", 2   * 1024 * 1024)) {
     log(Level.Verbose, "Post: [W] Upload too large: %d bytes from %s", expectedlength, request.ip);
     return(response.setPayload(StatusCode.PayloadTooLarge, "413 - Payload Too Large\n", "text/plain"));
   }

--- a/danode/process.d
+++ b/danode/process.d
@@ -117,14 +117,13 @@ class Process : Thread {
         char[4096] tmp;
         auto fp = file.getFP();
         ptrdiff_t n;
-        while (lastmodified < maxtime && buffer.data.length < serverConfig.get("max_cgi_output", 10 * 1024 * 1024)) {
+        auto maxOutput = serverConfig.get("max_cgi_output", 10 * 1024 * 1024);
+        while (lastmodified < maxtime && buffer.data.length < maxOutput) {
           n = fread(tmp.ptr, 1, tmp.sizeof, fp);
           if (n > 0) {
             modified = Clock.currTime();
             buffer.put(tmp[0 .. n]);
-          } else {
-            break;
-          }
+          } else { break; }
         }
       } catch (Exception e) { error("Exception during readpipe command: %s", e); file.close();
       } catch (Error e) { error("Error during readpipe command: %s", e); file.close();

--- a/danode/process.d
+++ b/danode/process.d
@@ -3,10 +3,10 @@
 module danode.process;
 
 import danode.imports;
+
 import danode.functions : Msecs;
 import danode.log : log, tag, error, Level;
-
-immutable size_t MAX_CGI_OUTPUT = 1024 * 1024 * 10; // 10MB script output limit
+import danode.webconfig : serverConfig;
 
 struct WaitResult {
   bool terminated; /// Is the process terminated
@@ -117,7 +117,7 @@ class Process : Thread {
         char[4096] tmp;
         auto fp = file.getFP();
         ptrdiff_t n;
-        while (lastmodified < maxtime && buffer.data.length < MAX_CGI_OUTPUT) {
+        while (lastmodified < maxtime && buffer.data.length < serverConfig.get("max_cgi_output", 10 * 1024 * 1024)) {
           n = fread(tmp.ptr, 1, tmp.sizeof, fp);
           if (n > 0) {
             modified = Clock.currTime();

--- a/danode/process.d
+++ b/danode/process.d
@@ -62,12 +62,12 @@ class Process : Thread {
     Appender!(char[])  errbuffer;           /// Error appender buffer
 
   public:
-    this(string[] command, string inputfile, string[string] environ, bool removeInput = true, long maxtime = 4500) {
+    this(string[] command, string inputfile, string[string] environ, bool removeInput = true) {
       this.command = command;
       this.inputfile = inputfile;
       this.environ = environ;
       this.removeInput = removeInput;
-      this.maxtime = maxtime;
+      this.maxtime = serverConfig.get("cgi_timeout", 4500L);
       this.starttime = Clock.currTime();
       this.modified = Clock.currTime();
       this.outbuffer = appender!(char[])();

--- a/danode/request.d
+++ b/danode/request.d
@@ -10,6 +10,7 @@ import danode.functions : interpreter, from, parseHtmlDate, parseQueryString;
 import danode.webconfig : WebConfig;
 import danode.post : PostItem, PostType;
 import danode.log : log, tag, error, Level;
+import danode.webconfig : serverConfig;
 
 // The Request-Method indicates which method is to be performed on the specified resource
 enum RequestMethod : string {
@@ -55,13 +56,13 @@ struct Request {
   long maxtime;  /// Maximum time in ms before the request is discarded
 
   // Start a new Request, and parseHeader on the DriverInterface
-  final void initialize(const DriverInterface driver, long maxtime = 4500) {
+  final void initialize(const DriverInterface driver) {
     this.ip = driver.ip;
     this.port = driver.port;
     this.body = driver.body;
     this.isSecure = driver.isSecure;
     this.starttime = Clock.currTime();
-    this.maxtime = maxtime;
+    this.maxtime = serverConfig.get("request_timeout", 5000L);
     this.id = md5UUID(format("%s:%d-%s", driver.ip, driver.port, starttime));
     this.isValid = this.parseHeader(driver.header);
     log(Level.Verbose, "request: %s to %s from %s:%d - %s", method, uri, this.ip, this.port, this.id);

--- a/danode/request.d
+++ b/danode/request.d
@@ -7,10 +7,9 @@ import danode.imports;
 import danode.filesystem : FileSystem;
 import danode.interfaces : DriverInterface;
 import danode.functions : interpreter, from, parseHtmlDate, parseQueryString;
-import danode.webconfig : WebConfig;
+import danode.webconfig : WebConfig, serverConfig;
 import danode.post : PostItem, PostType;
 import danode.log : log, tag, error, Level;
-import danode.webconfig : serverConfig;
 
 // The Request-Method indicates which method is to be performed on the specified resource
 enum RequestMethod : string {

--- a/danode/response.d
+++ b/danode/response.d
@@ -16,8 +16,6 @@ import danode.filesystem : FileSystem;
 import danode.post : serverAPI;
 import danode.functions : browseDir;
 
-immutable string SERVERINFO = "DaNode/0.0.3";
-
 struct Response {
   string            protocol = "HTTP/1.1";
   string            connection = "Close";
@@ -128,7 +126,7 @@ bool buildScriptHeader(ref Appender!(char[]) hdr, ref string connection, CGI scr
 Response create(in Request request, Address address, in StatusCode statuscode = StatusCode.Ok, in string mimetype = UNSUPPORTED_FILE){
   Response response = Response(request.protocol);
   response.address = address;
-  response.customheader("Server", SERVERINFO);
+  response.customheader("Server", serverConfig.get("serverinfo", "DaNode/0.0.3"));
   response.customheader("X-Powered-By", format("%s %s.%s", name, version_major, version_minor));
   response.payload = new Message(statuscode, "", mimetype);
   response.connection = request.keepalive ? "Keep-Alive" : "Close";

--- a/danode/response.d
+++ b/danode/response.d
@@ -11,7 +11,7 @@ import danode.request : Request;
 import danode.mimetypes : UNSUPPORTED_FILE;
 import danode.payload : Payload, PayloadType, HeaderType, Message;
 import danode.log : tag, log, Level;
-import danode.webconfig;
+import danode.webconfig : WebConfig, serverConfig;
 import danode.filesystem : FileSystem;
 import danode.post : serverAPI;
 import danode.functions : browseDir;

--- a/danode/response.d
+++ b/danode/response.d
@@ -165,7 +165,7 @@ void serveCGI(ref Response response, in Request request, in WebConfig config, in
     log(Level.Trace, "Writing server variables");
     fs.serverAPI(config, request, response);
     log(Level.Trace, "Creating CGI payload");
-    response.payload = new CGI(request.command(localpath), request.inputfile(fs), request.environ(localpath), removeInput, request.maxtime);
+    response.payload = new CGI(request.command(localpath), request.inputfile(fs), request.environ(localpath), removeInput);
     response.ready = true;
   }
 }

--- a/danode/response.d
+++ b/danode/response.d
@@ -159,25 +159,21 @@ void domainNotFound(ref Response response) {
 }
 
 // serve a the output of an external script 
-void serveCGI(ref Response response, in Request request, in WebConfig config, in FileSystem fs, bool removeInput = true) {
+void serveCGI(ref Response response, in Request request, in WebConfig config, in FileSystem fs, string localpath, bool removeInput = true) {
   log(Level.Trace, "Requested a cgi file, execution allowed");
-  string localroot = fs.localroot(request.shorthost());
-  string localpath = config.localpath(localroot, request.path);
   if (!response.routed) { // Store POST data (could fail multiple times)
     log(Level.Trace, "Writing server variables");
     fs.serverAPI(config, request, response);
     log(Level.Trace, "Creating CGI payload");
-    response.payload = new CGI(request.command(localpath), request.inputfile(fs), request.environ(localpath), removeInput, request.maxtime-5);
+    response.payload = new CGI(request.command(localpath), request.inputfile(fs), request.environ(localpath), removeInput, request.maxtime);
     response.ready = true;
   }
 }
 
 // serve a directory browsing request, via a message
-void serveDirectory(ref Response response, ref Request request, in WebConfig config, in FileSystem fs) {
+void serveDirectory(ref Response response, ref Request request, in WebConfig config, in FileSystem fs, string localpath) {
   log(Level.Trace, "Sending browse directory");
-  string localroot = fs.localroot(request.shorthost());
-  string localpath = config.localpath(localroot, request.path);
-  response.setPayload(StatusCode.Ok, browseDir(localroot, localpath), "text/html");
+  response.setPayload(StatusCode.Ok, browseDir(fs.localroot(request.shorthost()), localpath), "text/html");
 }
 
 // serve a forbidden page

--- a/danode/router.d
+++ b/danode/router.d
@@ -154,8 +154,7 @@ StringDriver runRequest(Router router, string request = "GET /dmd.d HTTP/1.1\nHo
   auto driver = new StringDriver(request);
   auto client = new Client(router, driver, maxtime);
   log(Level.Verbose, "Router: [I] %s:%s %s", client.ip(), client.port(), request.splitLines()[0]);
-  client.start();
-  client.join();
+  client.run();
   return driver;
 }
 

--- a/danode/router.d
+++ b/danode/router.d
@@ -33,18 +33,18 @@ class Router {
     }
 
     // Parse the header of a request, or receive additional post data when the user is uploading
-    final bool parse(in DriverInterface driver, ref Request request, ref Response response, long maxtime = 4500) {
+    final bool parse(in DriverInterface driver, ref Request request, ref Response response) {
       if (!driver.hasHeader()) return(false);
       if (!response.created) {
-        request.initialize(driver, maxtime);
+        request.initialize(driver);
         response = request.create(this.address);
       } else { request.update(driver.body); }
       return(true);
     }
 
     // Route a request based on the request header
-    final void route(DriverInterface driver, ref Request request, ref Response response, long maxtime = 4500) {
-      if (!response.routed && parse(driver, request, response, maxtime)) {
+    final void route(DriverInterface driver, ref Request request, ref Response response) {
+      if (!response.routed && parse(driver, request, response)) {
         if (request.parsePost(response, filesystem)) { deliver(request, response); }
       }
     }

--- a/danode/router.d
+++ b/danode/router.d
@@ -87,7 +87,7 @@ class Router {
         log(Level.Trace, "Router: [T] allowcgi: %s, localpath %s exists", config.allowcgi, localpath);
         if (pathIsCGI && config.allowcgi) {
           log(Level.Trace, "Router: [T] localpath %s is a CGI file", localpath);
-          return(response.serveCGI(request, config, filesystem));
+          return(response.serveCGI(request, config, filesystem, localpath));
         }
         if (pathIsFILE && !pathIsCGI && pathAllowed) {
           log(Level.Trace, "Router: [T] localpath %s is a normal file", localpath);
@@ -100,7 +100,7 @@ class Router {
             if (!config.allowcgi) return(response.notFound());
             return(redirectCanonical(config, request, response));
           }
-          return(response.serveDirectory(request, config, filesystem));
+          return(response.serveDirectory(request, config, filesystem, localpath));
         }
         return(response.forbidden());
       }

--- a/danode/server.d
+++ b/danode/server.d
@@ -126,7 +126,6 @@ class Server : Thread {
         } catch(Exception e) { error("Unspecified top level server exception: %s", e.msg);
         } catch(Error e) { error("Unspecified top level server error: %s", e.msg); }
       }
-      pool.stop();
       socket.close();
       version (SSL) { sslsocket.closeSSL(); }
     }

--- a/danode/server.d
+++ b/danode/server.d
@@ -11,6 +11,7 @@ import danode.http : HTTP;
 import danode.router : Router;
 import danode.signals : shutdownSignal;
 import danode.workerpool : WorkerPool;
+import danode.webconfig : serverConfig;
 
 version(SSL) {
   import danode.acme : checkAndRenew;
@@ -137,6 +138,7 @@ void main(string[] args) {
                "accountKey",  &accountKey,   // Server Let's encrypt account key
                "verbose|v",   &verbose);     // Verbose level (via commandline)
   atomicStore(cv, verbose);
+  synchronized(serverConfigMutex) {  ServerConfig(wwwFolder ~ "server.config"); }
   version(Posix) {
     import danode.signals : setupPosix;
     setupPosix();

--- a/danode/server.d
+++ b/danode/server.d
@@ -8,6 +8,7 @@ import danode.client : Client;
 import danode.interfaces : DriverInterface;
 import danode.http : HTTP;
 import danode.router : Router;
+import danode.workerpool : WorkerPool;
 import danode.log : cv, abort, log, tag, error, Level;
 
 version(SSL) {
@@ -16,18 +17,13 @@ version(SSL) {
   import danode.https : HTTPS;
 }
 
-immutable int MAX_CLIENTS = 2048;
-immutable int MAX_CLIENTS_PER_IP = 32;
-
 class Server : Thread {
   private:
     Socket              socket;                 // The server socket
     SocketSet           set;                    // SocketSet for server socket and client listeners
-    Client[]            clients;                // List of clients
     bool                terminated;             // Server running
     SysTime             starttime;              // Start time of the server
-    Router              router;                 // Router to route requests
-    long[string]        nAlivePerIP;
+    WorkerPool          pool;
 
   public:
     string wwwFolder    = "www/";
@@ -46,7 +42,7 @@ class Server : Thread {
          string sslFolder = ".ssl/", string sslKey = "server.key", string accountKey = "account.key") {
       starttime = Clock.currTime();                             // Start the timer
       socket = initialize(port, backlog);                       // Create the HTTP socket
-      router = new Router(wwwFolder, socket.localAddress());    // Start the router
+      pool = new WorkerPool(new Router(wwwFolder, socket.localAddress()));
       version(SSL) {
         sslPath = sslFolder.resolveFolder();
         ssl = sslKey;
@@ -73,20 +69,22 @@ class Server : Thread {
     }
 
     // Accept an incoming connection and create a client object
-    final void accept(ref Appender!(Client[]) persistent, Socket socket, bool secure = false) {
-      if (set.sISelect(socket, false, 5) <= 0 || nAlive >= MAX_CLIENTS) return;
-      log(Level.Trace, "Accepting %s request", secure ? "HTTPs" : "HTTP");
+    final void accept(Socket socket, bool secure = false) {
+      if (set.sISelect(socket, false, 5) <= 0) return;
       try {
-          DriverInterface driver = null;
-          if (!secure) driver = new HTTP(socket.accept(), false);
-          version(SSL) { if (secure) driver = new HTTPS(socket.accept(), false); }
-          if (driver is null) return;
-          Client client = new Client(router, driver);
-          client.start();
-          if (nAlivePerIP.from(client.ip, 0L) <= MAX_CLIENTS_PER_IP) {
-            persistent.put(client);
-          } else { log(Level.Always, "Rate limit exceeded [%s]", client.ip); client.stop(); }
-      } catch(Exception e) { error("Unable to accept connection: %s", e.msg); }
+        Socket accepted = socket.accept();
+        string ip = accepted.remoteAddress().toAddrString();
+        bool isLoopback = (ip == "127.0.0.1" || ip == "::1");
+        DriverInterface driver = null;
+        if (!secure) driver = new HTTP(accepted, false);
+        version(SSL) { if (secure) driver = new HTTPS(accepted, false); }
+        if (driver is null) { accepted.close(); return; }
+        if (!pool.push(driver, ip, isLoopback)) {
+          log(Level.Always, "Rate limit or capacity exceeded [%s]", ip);
+          driver.closeConnection();
+        }
+      } catch(Exception e) { error("Unable to accept connection, Exception: %s", e.msg);
+      } catch(Error e) { error("Unable to accept connection, Error: %s", e.msg); }
     }
 
     // is the server still running ?
@@ -98,19 +96,15 @@ class Server : Thread {
       }
     } }
 
-    // Stop all clients and shutdown the server
-    final void stop(){ synchronized {
-      foreach(ref Client client; clients){ client.stop(); } terminated = true;
-    } }
-
-    final @property long nAlive() { return nAlivePerIP.byValue.sum; }
+    // Stop the pool and shutdown the server
+    final void stop(){ synchronized { pool.stop(); terminated = true; } }
 
      // Returns a Duration object holding the server uptime
     final @property Duration uptime() const { return(Clock.currTime() - starttime); }
 
-     // Print some server information
-    final @property void info() { log(Level.Always, "Uptime %s, Connections: %d / %d", uptime, nAlive, clients.length); }
-    
+    // Print some server information
+    final @property void info() { log(Level.Always, "Uptime %s, Connections: %d / queued: %d", uptime, pool.nAlive, pool.queued); }
+
     // Hostname of the server
     final @property string hostname() { return(socket.hostName()); }
     version(SSL) {
@@ -119,42 +113,43 @@ class Server : Thread {
     }
 
     final void run() {
-      Appender!(Client[]) persistent;
       SysTime lastScan = Clock.currTime();
       while(running) {
         try {
-          Client[] previous = clients;                            // Slice reference
-          persistent.clear();                                     // Clear the Appender
-          accept(persistent, socket);
-          version (SSL) { accept(persistent, sslsocket, true); }
-
-          nAlivePerIP = null;
-          foreach (Client client; previous) {   // Foreach through the Slice reference
-            if(client.running) { nAlivePerIP[client.ip]++; persistent.put(client); }
-            else if(!client.isRunning) client.join();           // join finished threads
-          }
-          clients = persistent.data;
-          if (Msecs(lastScan) > 86_400_000) {   // Scan for deleted files & expiring certificates every day
-            router.scan();
+          accept(socket);
+          version (SSL) { accept(sslsocket, true); }
+          if (Msecs(lastScan) > 86_400_000) {
+            pool.scan();
             version(SSL) { checkAndRenew(sslPath, sslKey, accountKey); }
             lastScan = Clock.currTime();
           }
         } catch(Exception e) { error("Unspecified top level server exception: %s", e.msg);
         } catch(Error e) { error("Unspecified top level server error: %s", e.msg); }
       }
-      log(Level.Always, "Server socket closed, running: %s", running);
+      pool.stop();
       socket.close();
       version (SSL) { sslsocket.closeSSL(); }
     }
 }
 
-void parseKeyInput(ref Server server){
+void parseKeyInput(ref Server server) {
   string line = chomp(stdin.readln());
   if (line.startsWith("quit")) server.stop();
   if (line.startsWith("info")) server.info();
 }
 
+void setLimit() { version(Posix) {
+  import core.sys.posix.sys.resource;
+
+  rlimit rl;
+  getrlimit(RLIMIT_NOFILE, &rl);
+  rl.rlim_cur = rl.rlim_max;
+  auto res = setrlimit(RLIMIT_NOFILE, &rl);
+  log(Level.Always, "FD limit: %d [%d]", rl.rlim_cur, res);
+} }
+
 void main(string[] args) {
+  setLimit();
   version(unittest){ ushort port = 8080; }else{ ushort port = 80; }
   int    backlog      = 100;
   int    verbose      = Level.Verbose;

--- a/danode/server.d
+++ b/danode/server.d
@@ -97,9 +97,9 @@ class Server {
       final @property string accountKey() { return(sslPath ~ account); }
     }
 
-     @property bool alive() {
-      version(SSL) { return socket.isAlive() && sslsocket.isAlive();
-      } else { return socket.isAlive(); }
+    @property bool alive() {
+      version(SSL) { return(socket.isAlive() && sslsocket.isAlive());
+      } else { return(socket.isAlive()); }
     }
 
     final void run() {

--- a/danode/server.d
+++ b/danode/server.d
@@ -97,7 +97,7 @@ class Server {
     }
 
     @property bool alive() {
-      if (atomicLoad!(shutdownSignal)) return false;
+      if (atomicLoad(shutdownSignal)) return false;
       version(SSL) { return(socket.isAlive() && sslsocket.isAlive());
       } else { return(socket.isAlive()); }
     }
@@ -147,7 +147,7 @@ void main(string[] args) {
     loadSSL(server.sslPath, server.sslKey);                             // Load SSL certificates
     checkAndRenew(server.sslPath, server.sslKey, server.accountKey);    // checkAndRenew SSL certificates
   }
-  server.run();
+  return(server.run());
 }
 
 unittest {

--- a/danode/server.d
+++ b/danode/server.d
@@ -11,7 +11,7 @@ import danode.http : HTTP;
 import danode.router : Router;
 import danode.signals : shutdownSignal;
 import danode.workerpool : WorkerPool;
-import danode.webconfig : serverConfig, serverConfigMutex;
+import danode.webconfig : serverConfig, ServerConfig, serverConfigMutex;
 
 version(SSL) {
   import danode.acme : checkAndRenew;

--- a/danode/server.d
+++ b/danode/server.d
@@ -97,9 +97,14 @@ class Server {
       final @property string accountKey() { return(sslPath ~ account); }
     }
 
+     @property bool alive() {
+      version(SSL) { return socket.isAlive() && sslsocket.isAlive();
+      } else { return socket.isAlive(); }
+    }
+
     final void run() {
       SysTime lastScan = Clock.currTime();
-      while(socket.isAlive()) {
+      while(alive) {
         try {
           accept(socket);
           version (SSL) { accept(sslsocket, true); }
@@ -133,7 +138,7 @@ void main(string[] args) {
                "accountKey",  &accountKey,   // Server Let's encrypt account key
                "verbose|v",   &verbose);     // Verbose level (via commandline)
   atomicStore(cv, verbose);
-  version(Posix){ 
+  version(Posix) {
     import danode.signals : setupPosix;
     setupPosix();
   }

--- a/danode/server.d
+++ b/danode/server.d
@@ -11,7 +11,7 @@ import danode.http : HTTP;
 import danode.router : Router;
 import danode.signals : shutdownSignal;
 import danode.workerpool : WorkerPool;
-import danode.webconfig : serverConfig;
+import danode.webconfig : serverConfig, serverConfigMutex;
 
 version(SSL) {
   import danode.acme : checkAndRenew;

--- a/danode/server.d
+++ b/danode/server.d
@@ -97,7 +97,7 @@ class Server {
     }
 
     @property bool alive() {
-      if (shutdownSignal) return false;
+      if (atomicLoad!(shutdownSignal)) return false;
       version(SSL) { return(socket.isAlive() && sslsocket.isAlive());
       } else { return(socket.isAlive()); }
     }
@@ -116,8 +116,7 @@ class Server {
         } catch(Exception e) { error("Unspecified top level server exception: %s", e.msg);
         } catch(Error e) { error("Unspecified top level server error: %s", e.msg); }
       }
-      socket.close();
-      version (SSL) { sslsocket.closeSSL(); }
+      stop();
     }
 }
 

--- a/danode/server.d
+++ b/danode/server.d
@@ -16,11 +16,10 @@ version(SSL) {
   import danode.https : HTTPS;
 }
 
-class Server : Thread {
+class Server {
   private:
     Socket              socket;                 // The server socket
     SocketSet           set;                    // SocketSet for server socket and client listeners
-    bool                terminated;             // Server running
     SysTime             starttime;              // Start time of the server
     WorkerPool          pool;
 
@@ -47,7 +46,6 @@ class Server : Thread {
       }
       set = new SocketSet(1);                       // Create a server socket set
       log(Level.Always, "Server '%s' created backlog: %d", this.hostname(), backlog);
-      super(&run);
     }
 
     // Initialize the listening socket to a certain port and backlog
@@ -83,14 +81,8 @@ class Server : Thread {
       } catch(Error e) { error("Unable to accept connection, Error: %s", e.msg); }
     }
 
-    // is the server still running ?
-    final @property bool running() { synchronized {
-      version(SSL) { return(socket.isAlive() && sslsocket.isAlive() && !terminated);
-      } else { return(socket.isAlive() && !terminated); }
-    } }
-
     // Stop the pool and shutdown the server
-    final void stop(){ synchronized { pool.stop(); terminated = true; } }
+    final void stop(){ pool.stop(); }
 
      // Returns a Duration object holding the server uptime
     final @property Duration uptime() const { return(Clock.currTime() - starttime); }
@@ -107,7 +99,7 @@ class Server : Thread {
 
     final void run() {
       SysTime lastScan = Clock.currTime();
-      while(running) {
+      while(socket.isAlive()) {
         try {
           accept(socket);
           version (SSL) { accept(sslsocket, true); }
@@ -124,16 +116,10 @@ class Server : Thread {
     }
 }
 
-void parseKeyInput(ref Server server) {
-  string line = chomp(stdin.readln());
-  if (line.startsWith("quit")) server.stop();
-  if (line.startsWith("info")) server.info();
-}
-
 void main(string[] args) {
+  ushort port         = 80;
   int    backlog      = 100;
   int    verbose      = Level.Verbose;
-  bool   keyoff       = false;
   string wwwFolder    = "www/";
   string sslFolder    = ".ssl/";
   string sslKey       = "server.key";
@@ -141,31 +127,23 @@ void main(string[] args) {
 
   getopt(args, "port|p",      &port,         // Port to listen on
                "backlog|b",   &backlog,      // Backlog of clients supported
-               "keyoff|k",    &keyoff,       // Keyboard on or off
                "www",         &wwwFolder,    // Server www root folder
                "ssl",         &sslFolder,    // Location of SSL certificates
                "sslKey",      &sslKey,       // Server private key
                "accountKey",  &accountKey,   // Server Let's encrypt account key
                "verbose|v",   &verbose);     // Verbose level (via commandline)
   atomicStore(cv, verbose);
-  version(Posix) setupPosix();
-  version (Windows) {
-    log(Level.Always, "-k was set to true. However, keyboard input under windows is not supported");
-    keyoff = true;
+  version(Posix){ 
+    import danode.signals : setupPosix;
+    setupPosix();
   }
+
   auto server = new Server(port, backlog, wwwFolder, sslFolder, sslKey, accountKey);
   version (SSL) {
     loadSSL(server.sslPath, server.sslKey);                             // Load SSL certificates
     checkAndRenew(server.sslPath, server.sslKey, server.accountKey);    // checkAndRenew SSL certificates
   }
-  server.start();
-  while (server.running) {
-    if (!keyoff) { server.parseKeyInput(); }
-    stdout.flush();
-    Thread.sleep(dur!"msecs"(250));
-  }
-  log(Level.Always, "Server shutting down: %d", server.running);
-  server.info();
+  server.run();
 }
 
 unittest {

--- a/danode/server.d
+++ b/danode/server.d
@@ -35,8 +35,8 @@ class Server {
   public:
     this(ushort port = 80, int backlog = 100, string wwwFolder = "www/",
          string sslFolder = ".ssl/", string sslKey = "server.key", string accountKey = "account.key") {
-      starttime = Clock.currTime();                             // Start the timer
-      socket = initialize(port, backlog);                       // Create the HTTP socket
+      starttime = Clock.currTime(); // Start the timer
+      socket = initialize(port, backlog); // Create the HTTP socket
       pool = new WorkerPool(new Router(wwwFolder, socket.localAddress()));
       version(SSL) {
         sslPath = sslFolder.resolveFolder();
@@ -44,7 +44,7 @@ class Server {
         account = accountKey;
         sslsocket = initialize(443, backlog);  // Create the SSL / HTTPs socket
       }
-      set = new SocketSet(1);                       // Create a server socket set
+      set = new SocketSet();
       log(Level.Always, "Server '%s' created backlog: %d", this.hostname(), backlog);
     }
 

--- a/danode/server.d
+++ b/danode/server.d
@@ -138,7 +138,7 @@ void main(string[] args) {
                "accountKey",  &accountKey,   // Server Let's encrypt account key
                "verbose|v",   &verbose);     // Verbose level (via commandline)
   atomicStore(cv, verbose);
-  synchronized(serverConfigMutex) {  ServerConfig(wwwFolder ~ "server.config"); }
+  synchronized(serverConfigMutex) { serverConfig = ServerConfig(wwwFolder ~ "server.config"); }
   version(Posix) {
     import danode.signals : setupPosix;
     setupPosix();

--- a/danode/server.d
+++ b/danode/server.d
@@ -74,7 +74,7 @@ class Server {
         DriverInterface driver = null;
         if (!secure) driver = new HTTP(accepted, false);
         version(SSL) { if (secure) driver = new HTTPS(accepted, false); }
-        if (driver is null) { return(accepted.close()); }
+        if (driver is null) { accepted.close(); return; }
         if (!pool.push(driver, ip, isLoopback)) {
           log(Level.Always, "Rate limit or capacity exceeded [%s]", ip);
           driver.closeConnection();

--- a/danode/server.d
+++ b/danode/server.d
@@ -3,12 +3,14 @@
 module danode.server;
 
 import danode.imports;
+
+import danode.log : cv, abort, log, tag, error, Level;
 import danode.functions : Msecs, sISelect, resolveFolder;
 import danode.interfaces : DriverInterface;
 import danode.http : HTTP;
 import danode.router : Router;
+import danode.signals : shutdownSignal;
 import danode.workerpool : WorkerPool;
-import danode.log : cv, abort, log, tag, error, Level;
 
 version(SSL) {
   import danode.acme : checkAndRenew;
@@ -82,13 +84,10 @@ class Server {
     }
 
     // Stop the pool and shutdown the server
-    final void stop(){ pool.stop(); }
+    final void stop() { pool.stop(); socket.close(); version(SSL) { sslsocket.closeSSL(); } }
 
-     // Returns a Duration object holding the server uptime
+    // Returns a Duration object holding the server uptime
     final @property Duration uptime() const { return(Clock.currTime() - starttime); }
-
-    // Print some server information
-    final @property void info() { log(Level.Always, "Uptime %s, Connections: %d / queued: %d", uptime, pool.nAlive, pool.queued); }
 
     // Hostname of the server
     final @property string hostname() { return(socket.hostName()); }
@@ -98,6 +97,7 @@ class Server {
     }
 
     @property bool alive() {
+      if (shutdownSignal) return false;
       version(SSL) { return(socket.isAlive() && sslsocket.isAlive());
       } else { return(socket.isAlive()); }
     }

--- a/danode/server.d
+++ b/danode/server.d
@@ -3,8 +3,7 @@
 module danode.server;
 
 import danode.imports;
-import danode.functions : from, Msecs, sISelect, resolveFolder;
-import danode.client : Client;
+import danode.functions : Msecs, sISelect, resolveFolder;
 import danode.interfaces : DriverInterface;
 import danode.http : HTTP;
 import danode.router : Router;
@@ -24,9 +23,6 @@ class Server : Thread {
     bool                terminated;             // Server running
     SysTime             starttime;              // Start time of the server
     WorkerPool          pool;
-
-  public:
-    string wwwFolder    = "www/";
 
     version(SSL) {
       private:
@@ -78,7 +74,7 @@ class Server : Thread {
         DriverInterface driver = null;
         if (!secure) driver = new HTTP(accepted, false);
         version(SSL) { if (secure) driver = new HTTPS(accepted, false); }
-        if (driver is null) { accepted.close(); return; }
+        if (driver is null) { return(accepted.close()); }
         if (!pool.push(driver, ip, isLoopback)) {
           log(Level.Always, "Rate limit or capacity exceeded [%s]", ip);
           driver.closeConnection();
@@ -88,12 +84,9 @@ class Server : Thread {
     }
 
     // is the server still running ?
-    final @property bool running(){ synchronized {
-      version(SSL) {
-        return(socket.isAlive() && sslsocket.isAlive() && !terminated);
-      } else {
-        return(socket.isAlive() && !terminated);
-      }
+    final @property bool running() { synchronized {
+      version(SSL) { return(socket.isAlive() && sslsocket.isAlive() && !terminated);
+      } else { return(socket.isAlive() && !terminated); }
     } }
 
     // Stop the pool and shutdown the server
@@ -137,19 +130,7 @@ void parseKeyInput(ref Server server) {
   if (line.startsWith("info")) server.info();
 }
 
-void setLimit() { version(Posix) {
-  import core.sys.posix.sys.resource;
-
-  rlimit rl;
-  getrlimit(RLIMIT_NOFILE, &rl);
-  rl.rlim_cur = rl.rlim_max;
-  auto res = setrlimit(RLIMIT_NOFILE, &rl);
-  log(Level.Always, "FD limit: %d [%d]", rl.rlim_cur, res);
-} }
-
 void main(string[] args) {
-  setLimit();
-  version(unittest){ ushort port = 8080; }else{ ushort port = 80; }
   int    backlog      = 100;
   int    verbose      = Level.Verbose;
   bool   keyoff       = false;
@@ -157,7 +138,7 @@ void main(string[] args) {
   string sslFolder    = ".ssl/";
   string sslKey       = "server.key";
   string accountKey   = "account.key";
-  
+
   getopt(args, "port|p",      &port,         // Port to listen on
                "backlog|b",   &backlog,      // Backlog of clients supported
                "keyoff|k",    &keyoff,       // Keyboard on or off
@@ -167,32 +148,24 @@ void main(string[] args) {
                "accountKey",  &accountKey,   // Server Let's encrypt account key
                "verbose|v",   &verbose);     // Verbose level (via commandline)
   atomicStore(cv, verbose);
-  version (unittest) {
-    // Do nothing, unittests will run
-  } else {
-    version (Posix) {
-      import core.sys.posix.signal : signal, SIGPIPE;
-      import danode.signals : handle_signal;
-      signal(SIGPIPE, &handle_signal);
-    }
-    version (Windows) {
-      log(Level.Always, "-k was set to true. However, keyboard input under windows is not supported");
-      keyoff = true;
-    }
-    auto server = new Server(port, backlog, wwwFolder, sslFolder, sslKey, accountKey);
-    version (SSL) {
-      loadSSL(server.sslPath, server.sslKey);                             // Load SSL certificates
-      checkAndRenew(server.sslPath, server.sslKey, server.accountKey);    // checkAndRenew SSL certificates
-    }
-    server.start();
-    while (server.running) {
-      if (!keyoff) { server.parseKeyInput(); }
-      stdout.flush();
-      Thread.sleep(dur!"msecs"(250));
-    }
-    log(Level.Always, "Server shutting down: %d", server.running);
-    server.info();
+  version(Posix) setupPosix();
+  version (Windows) {
+    log(Level.Always, "-k was set to true. However, keyboard input under windows is not supported");
+    keyoff = true;
   }
+  auto server = new Server(port, backlog, wwwFolder, sslFolder, sslKey, accountKey);
+  version (SSL) {
+    loadSSL(server.sslPath, server.sslKey);                             // Load SSL certificates
+    checkAndRenew(server.sslPath, server.sslKey, server.accountKey);    // checkAndRenew SSL certificates
+  }
+  server.start();
+  while (server.running) {
+    if (!keyoff) { server.parseKeyInput(); }
+    stdout.flush();
+    Thread.sleep(dur!"msecs"(250));
+  }
+  log(Level.Always, "Server shutting down: %d", server.running);
+  server.info();
 }
 
 unittest {

--- a/danode/signals.d
+++ b/danode/signals.d
@@ -2,11 +2,13 @@
   * License: GPLv3 (https://github.com/DannyArends/DaNode) - Danny Arends **/
 module danode.signals;
 
+__gshared bool shutdownSignal = false;
+
 version(Posix) {
   import danode.imports;
 
   import core.sys.posix.sys.resource;
-  import core.sys.posix.signal : signal, SIGPIPE;
+  import core.sys.posix.signal : signal, SIGPIPE, SIGTERM, SIGINT;
   import core.sys.posix.unistd : write;
 
   import danode.log : cv, log, Level;
@@ -15,6 +17,10 @@ version(Posix) {
     switch (signal) {
       case SIGPIPE:
         if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    Broken pipe caught, and ignored\n\0".ptr, 41);
+        break;
+     case SIGTERM, SIGINT:
+        if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    SIGTERM/SIGINT\n\0".ptr, 24);
+        atomicStore(shutdownSignal, true);
         break;
       default:
         if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    Caught\n\0".ptr, 17);
@@ -29,6 +35,8 @@ version(Posix) {
     auto res = setrlimit(RLIMIT_NOFILE, &rl);
     log(Level.Always, "FD limit: %d [%d]", rl.rlim_cur, res);
     signal(SIGPIPE, &handleSignal);
+    signal(SIGTERM, &handleSignal);
+    signal(SIGINT,  &handleSignal);
   }
 }
 

--- a/danode/signals.d
+++ b/danode/signals.d
@@ -3,13 +3,15 @@
 module danode.signals;
 
 version(Posix) {
-  import core.sys.posix.unistd : write;
-  import core.sys.posix.signal : SIGPIPE;
-
   import danode.imports;
-  import danode.log : cv;
 
-  extern(C) @nogc nothrow void handle_signal(int signal) {
+  import core.sys.posix.sys.resource;
+  import core.sys.posix.signal : signal, SIGPIPE;
+  import core.sys.posix.unistd : write;
+
+  import danode.log : cv, log, Level;
+
+  extern(C) @nogc nothrow void handleSignal(int signal) {
     switch (signal) {
       case SIGPIPE:
         if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    Broken pipe caught, and ignored\n\0".ptr, 41);
@@ -18,6 +20,15 @@ version(Posix) {
         if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    Caught\n\0".ptr, 17);
         break;
     }
+  }
+
+  void setupPosix() {
+    rlimit rl;
+    getrlimit(RLIMIT_NOFILE, &rl);
+    rl.rlim_cur = rl.rlim_max;
+    auto res = setrlimit(RLIMIT_NOFILE, &rl);
+    log(Level.Always, "FD limit: %d [%d]", rl.rlim_cur, res);
+    signal(SIGPIPE, &handleSignal);
   }
 }
 

--- a/danode/signals.d
+++ b/danode/signals.d
@@ -1,8 +1,8 @@
-/** danode/signals.d - POSIX signal handling: SIGPIPE suppression
+/** danode/signals.d - POSIX signal handling: SIGPIPE suppression & clean shutdown via SIGTERM, SIGINT
   * License: GPLv3 (https://github.com/DannyArends/DaNode) - Danny Arends **/
 module danode.signals;
 
-__gshared bool shutdownSignal = false;
+shared bool shutdownSignal = false;
 
 version(Posix) {
   import danode.imports;

--- a/danode/signals.d
+++ b/danode/signals.d
@@ -23,7 +23,7 @@ version(Posix) {
         atomicStore(shutdownSignal, true);
         break;
       default:
-        if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    Caught\n\0".ptr, 17);
+        if(atomicLoad(cv) > 1) write(2, cast(const(void*)) "[SIG]    Caught\n\0".ptr, 16);
         break;
     }
   }

--- a/danode/ssl.d
+++ b/danode/ssl.d
@@ -6,6 +6,7 @@ version(SSL) {
   import danode.imports;
   import danode.includes;
 
+  import danode.functions : isFILE, isDIR;
   import danode.log : log, tag, error, Level;
 
   // SSL context structure, stored relation between hostname 
@@ -79,7 +80,7 @@ version(SSL) {
     SSL_CTX_set_options(ctx, 0x00400000U); //SSL_OP_CIPHER_SERVER_PREFERENCE
     SSL_CTX_set1_groups_list(ctx, "X25519:P-256:P-384");
 
-    if (exists(chainFile) && isFile(chainFile)) {
+    if (isFILE(chainFile)) {
       log(Level.Verbose, "SSL: [I] Loading certificate+chain from file: %s", chainFile);
       sslAssert(SSL_CTX_use_certificate_chain_file(ctx, cast(const char*) toStringz(chainFile)) > 0);
     } else {
@@ -132,17 +133,16 @@ version(SSL) {
   // Reload all SSL contexts from sslPath without restarting the server
   void loadSSL(string sslPath = ".ssl/", string sslKey = ".ssl/server.key") {
     log(Level.Verbose, "SSL: [I] loading sslPath: %s, sslKey: %s", sslPath, sslKey);
-    if (!exists(sslPath) || !isDir(sslPath)) { error("SSL: sslPath '%s' not found", sslPath); return; }
-    if (!exists(sslKey) || !isFile(sslKey)) { sslKey.generateKey(); }
+    if (!isDIR(sslPath)) { error("SSL: sslPath '%s' not found", sslPath); return; }
+    if (!isFILE(sslKey)) { sslKey.generateKey(); }
 
     SSLcontext[] localContexts;
     foreach (DirEntry d; dirEntries(sslPath, SpanMode.shallow)) {
       if (d.name.endsWith(".chain")) {
         string hostname = baseName(d.name, ".chain");
         if (hostname.length < 254) {
-          string chainFile = d.name;
-          log(Level.Verbose, "SSL: [I] Reloading certificate at: '%s'", chainFile);
-          auto lc = loadContext(chainFile, hostname, sslKey);
+          log(Level.Verbose, "SSL: [I] Reloading certificate at: '%s'", d.name);
+          auto lc = loadContext(d.name, hostname, sslKey);
           if (lc.context !is null) localContexts ~= lc;
         }
       }

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -8,27 +8,48 @@ import danode.functions : has, from;
 import danode.files : FilePayload;
 import danode.log : log, tag, Level;
 
-struct WebConfig {
+struct Config {
+  string[string] data;
+  SysTime mtime;
+}
+
+Config parseConfig(string content, string def = "no") {
+  Config config;
+  foreach (line; split(content, "\n")) {
+    if (chomp(strip(line)) == "" || line[0] == '#') continue;
+    auto parts = line.split("=");
+    string key = toLower(chomp(strip(parts[0])));
+    if (parts.length == 1) {
+      config.data[key] = def;
+    } else if (parts.length >= 2) {
+      config.data[key] = toLower(chomp(strip(join(parts[1 .. $], "="))));
+    }
+  }
+  return config;
+}
+
+struct ServerConfig {
   private:
-    string[string] data;
-    SysTime mtime;
+    Config config;
+    alias config this;
 
   public:
+    this(string path) {
+      if (!exists(path)) { log(Level.Trace, "No server.config at: '%s'", path); return; }
+      config = parseConfig(readText(path));
+      config.mtime = timeLastModified(path);
+    }
+}
 
+struct WebConfig {
+  private:
+    Config config;
+    alias config this;
+
+  public:
     this(FilePayload file, string def = "no") {
-      mtime = file.mtime;
-      string[] elements;
-      foreach (line; split(file.content, "\n")) {
-        if (chomp(strip(line)) != "" && line[0] != '#') {
-          elements = split(line, "=");
-          string key = toLower(chomp(strip(elements[0])));
-          if (elements.length == 1) {
-            data[key] = def;
-          }else if (elements.length >= 2) {
-            data[key] = toLower(chomp(strip(join(elements[1 .. $], "="))));
-          }
-        }
-      }
+      config = parseConfig(file.content, def);
+      config.mtime = file.mtime;
     }
 
   private @nogc bool flag(string key, string def, string match) const nothrow { return data.from(key, def) == match; }
@@ -89,17 +110,17 @@ unittest {
   WebConfig config = WebConfig(fp);
 
   // localhost web.config has: shorturl=yes, allowcgi=yes, redirect=dmd.d, allowdirs=ddoc/,test/
-  assert(config.allowcgi,                          "allowcgi must be yes");
-  assert(config.redirect(),                        "redirect must be set");
+  assert(config.allowcgi, "allowcgi must be yes");
+  assert(config.redirect(), "redirect must be set");
   assert(config.domain("localhost") == "localhost", "shorturl=yes must return shorthost");
-  assert(config.index() == "/dmd.d",               "index must be /dmd.d");
-  assert(!config.redirectdir(),                    "redirectdir must be no");
+  assert(config.index() == "/dmd.d", "index must be /dmd.d");
+  assert(!config.redirectdir(), "redirectdir must be no");
 
   // dirAllowed
   string localroot = fs.localroot("localhost");
-  assert(config.dirAllowed(localroot, localroot),            "root dir must be allowed");
-  assert(config.dirAllowed(localroot, localroot ~ "test/"),  "test/ must be allowed");
-  assert(!config.dirAllowed(localroot, localroot ~ "etc/"),  "etc/ must not be allowed");
+  assert(config.dirAllowed(localroot, localroot), "root dir must be allowed");
+  assert(config.dirAllowed(localroot, localroot ~ "test/"), "test/ must be allowed");
+  assert(!config.dirAllowed(localroot, localroot ~ "etc/"), "etc/ must not be allowed");
 
   // shorturl=no → www. prefix
   WebConfig noShort = WebConfig(fp);

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -112,11 +112,5 @@ unittest {
   WebConfig noShort = WebConfig(fp);
   noShort.data["shorturl"] = "no";
   assert(noShort.domain("localhost") == "www.localhost", "shorturl=no must add www.");
-
-  ServerConfig sc = ServerConfig("nonexistent.config");
-  assert(sc.maxClients()      == 2048, "default maxClients must be 2048");
-  assert(sc.maxClientsPerIP() == 32, "default maxClientsPerIP must be 32");
-  assert(sc.poolSize()        == 200, "default poolSize must be 200");
-  assert(sc.serverInfo()      == "DaNode/0.0.3", "default serverInfo must be set");
 }
 

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -8,6 +8,11 @@ import danode.functions : has, from;
 import danode.files : FilePayload;
 import danode.log : log, tag, Level;
 
+__gshared ServerConfig serverConfig;
+__gshared Mutex serverConfigMutex;
+
+shared static this() { serverConfigMutex = new Mutex(); }
+
 struct Config {
   string[string] data;
   SysTime mtime;
@@ -39,6 +44,23 @@ struct ServerConfig {
       config = parseConfig(readText(path));
       config.mtime = timeLastModified(path);
     }
+
+    @property int maxClients() const { return to!int(data.from("max_clients",        "2048")); }
+    @property int maxClientsPerIP() const { return to!int(data.from("max_clients_per_ip", "32")); }
+    @property int poolSize() const { return to!int(data.from("pool_size",          "200")); }
+    @property size_t maxHeaderSize() const { return to!size_t(data.from("max_header_size",  "32768")); }
+    @property size_t maxRequestSize() const { return to!size_t(data.from("max_request_size", "2097152")); }
+    @property size_t maxUploadSize() const { return to!size_t(data.from("max_upload_size",  "104857600")); }
+    @property size_t maxSSETime() const { return to!size_t(data.from("max_sse_time",     "60000")); }
+    @property size_t maxCGIOutput() const { return to!size_t(data.from("max_cgi_output",   "10485760")); }
+    @property long handshakeTimeout() const { return to!long(data.from("handshake_timeout",  "5000")); }
+    @property string serverInfo() const { return data.from("serverinfo", "DaNode/0.0.3"); }
+    @property string userEmail() const { return data.from("user_email", ""); }
+
+    T get(T)(string key, T def) { synchronized(serverConfigMutex) {
+      try { return to!T(data.from(key, to!string(def))); }
+      catch (Exception e) { return def; }
+    } }
 }
 
 struct WebConfig {
@@ -126,5 +148,11 @@ unittest {
   WebConfig noShort = WebConfig(fp);
   noShort.data["shorturl"] = "no";
   assert(noShort.domain("localhost") == "www.localhost", "shorturl=no must add www.");
+
+  ServerConfig sc = ServerConfig("nonexistent.config");
+  assert(sc.maxClients()      == 2048,           "default maxClients must be 2048");
+  assert(sc.maxClientsPerIP() == 32,             "default maxClientsPerIP must be 32");
+  assert(sc.poolSize()        == 200,            "default poolSize must be 200");
+  assert(sc.serverInfo()      == "DaNode/0.0.3", "default serverInfo must be set");
 }
 

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -1,4 +1,4 @@
-/** danode/webconfig.d - Per-domain web.config parsing: CGI, redirects, directory access control
+/** danode/webconfig.d - Server configuration and per-domain web.config parsing: CGI, redirects, directory access control
   * License: GPLv3 (https://github.com/DannyArends/DaNode) - Danny Arends **/
 module danode.webconfig;
 
@@ -68,54 +68,33 @@ struct WebConfig {
     Config config;
     alias config this;
 
+    @nogc bool flag(string key, string def, string match) const nothrow { return data.from(key, def) == match; }
+
   public:
     this(FilePayload file, string def = "no") {
       config = parseConfig(file.content, def);
       config.mtime = file.mtime;
     }
 
-  private @nogc bool flag(string key, string def, string match) const nothrow { return data.from(key, def) == match; }
+    @property string domain(string shorthost) const { return flag("shorturl", "yes", "yes") ? shorthost : format("www.%s", shorthost); }
+    @property @nogc bool allowcgi() const nothrow { return flag("allowcgi",    "no", "yes"); }
+    @property string localpath(in string localroot, in string path) const { return(format("%s%s", localroot, path)); }
+    @property @nogc bool redirect() const nothrow { return !flag("redirect",   "/",  "/"); }
+    @property @nogc bool redirectdir() const nothrow { return !flag("redirectdir","no", "no"); }
+    @property string index() const { string to = data.from("redirect", "/"); if (to[0] != '/') { return(format("/%s", to)); } return(to); }
+    @property string[] allowdirs() const nothrow { return(data.from("allowdirs", "/").split(",")); }
 
-  // Which domain is the prefered domain to be used: http://www.xxx.nl or http://xxx.nl
-  @property string domain(string shorthost) const { return flag("shorturl", "yes", "yes") ? shorthost : format("www.%s", shorthost); }
-
-  // Is CGI allowed ?
-  @property @nogc bool allowcgi()    const nothrow { return flag("allowcgi",    "no", "yes"); }
-
-  // concats localroot with the path specified
-  @property string localpath(in string localroot, in string path) const {
-    return(format("%s%s", localroot, path));
-  }
-
-  // Should redirection be performed ?
-  @property @nogc bool redirect() const nothrow { return !flag("redirect",   "/",  "/"); }
-
-  // Should directories be redirected to the index page ?
-  @property @nogc bool redirectdir() const nothrow { return !flag("redirectdir","no", "no"); }
-
-  // What index page is specified in the 'redirect' option in the web.config file
-  @property string index() const {
-    string to = data.from("redirect", "/");
-    if (to[0] != '/') return(format("/%s", to));
-    return(to);
-  }
-
-  // All directories listed in the allowdirs option in the web.config file
-  @property string[] allowdirs() const nothrow { 
-    return(data.from("allowdirs", "/").split(","));
-  }
-
-  // Is the directory allowed to be viewed ?
-  @property bool dirAllowed(in string localroot, in string path) const {
-    string root = localroot.endsWith("/") ? localroot : localroot ~ "/";
-    string p = path.startsWith(root) ? path : path.replace(localroot, root);
-    if (p.length <= root.length) return true;
-    string npath = p[root.length .. $];
-    foreach (d; allowdirs) {
-      if (indexOf(strip(npath), strip(d)) == 0) return true;
+    // Is the directory allowed to be viewed ?
+    @property bool dirAllowed(in string localroot, in string path) const {
+      string root = localroot.endsWith("/") ? localroot : localroot ~ "/";
+      string p = path.startsWith(root) ? path : path.replace(localroot, root);
+      if (p.length <= root.length) return true;
+      string npath = p[root.length .. $];
+      foreach (d; allowdirs) {
+        if (indexOf(strip(npath), strip(d)) == 0) return true;
+      }
+      return false;
     }
-    return false;
-  }
 }
 
 WebConfig getConfig(ref WebConfig[string] configs, FilePayload fp, string key) {

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -45,18 +45,6 @@ struct ServerConfig {
       config.mtime = timeLastModified(path);
     }
 
-    @property int maxClients() const { return to!int(data.from("max_clients", "2048")); }
-    @property int maxClientsPerIP() const { return to!int(data.from("max_clients_per_ip", "32")); }
-    @property int poolSize() const { return to!int(data.from("pool_size", "200")); }
-    @property size_t maxHeaderSize() const { return to!size_t(data.from("max_header_size", "32768")); }
-    @property size_t maxRequestSize() const { return to!size_t(data.from("max_request_size", "2097152")); }
-    @property size_t maxUploadSize() const { return to!size_t(data.from("max_upload_size", "104857600")); }
-    @property size_t maxSSETime() const { return to!size_t(data.from("max_sse_time", "60000")); }
-    @property size_t maxCGIOutput() const { return to!size_t(data.from("max_cgi_output", "10485760")); }
-    @property long handshakeTimeout() const { return to!long(data.from("handshake_timeout", "5000")); }
-    @property string serverInfo() const { return data.from("serverinfo", "DaNode/0.0.3"); }
-    @property string userEmail() const { return data.from("user_email", ""); }
-
     T get(T)(string key, T def) { synchronized(serverConfigMutex) {
       try { return to!T(data.from(key, to!string(def))); }
       catch (Exception e) { return def; }
@@ -78,7 +66,6 @@ struct WebConfig {
 
     @property string domain(string shorthost) const { return flag("shorturl", "yes", "yes") ? shorthost : format("www.%s", shorthost); }
     @property @nogc bool allowcgi() const nothrow { return flag("allowcgi", "no", "yes"); }
-    @property string localpath(in string localroot, in string path) const { return(format("%s%s", localroot, path)); }
     @property @nogc bool redirect() const nothrow { return !flag("redirect", "/",  "/"); }
     @property @nogc bool redirectdir() const nothrow { return !flag("redirectdir","no", "no"); }
     @property string index() const { string to = data.from("redirect", "/"); if (to[0] != '/') { return(format("/%s", to)); } return(to); }

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -45,15 +45,15 @@ struct ServerConfig {
       config.mtime = timeLastModified(path);
     }
 
-    @property int maxClients() const { return to!int(data.from("max_clients",        "2048")); }
+    @property int maxClients() const { return to!int(data.from("max_clients", "2048")); }
     @property int maxClientsPerIP() const { return to!int(data.from("max_clients_per_ip", "32")); }
-    @property int poolSize() const { return to!int(data.from("pool_size",          "200")); }
-    @property size_t maxHeaderSize() const { return to!size_t(data.from("max_header_size",  "32768")); }
+    @property int poolSize() const { return to!int(data.from("pool_size", "200")); }
+    @property size_t maxHeaderSize() const { return to!size_t(data.from("max_header_size", "32768")); }
     @property size_t maxRequestSize() const { return to!size_t(data.from("max_request_size", "2097152")); }
-    @property size_t maxUploadSize() const { return to!size_t(data.from("max_upload_size",  "104857600")); }
-    @property size_t maxSSETime() const { return to!size_t(data.from("max_sse_time",     "60000")); }
-    @property size_t maxCGIOutput() const { return to!size_t(data.from("max_cgi_output",   "10485760")); }
-    @property long handshakeTimeout() const { return to!long(data.from("handshake_timeout",  "5000")); }
+    @property size_t maxUploadSize() const { return to!size_t(data.from("max_upload_size", "104857600")); }
+    @property size_t maxSSETime() const { return to!size_t(data.from("max_sse_time", "60000")); }
+    @property size_t maxCGIOutput() const { return to!size_t(data.from("max_cgi_output", "10485760")); }
+    @property long handshakeTimeout() const { return to!long(data.from("handshake_timeout", "5000")); }
     @property string serverInfo() const { return data.from("serverinfo", "DaNode/0.0.3"); }
     @property string userEmail() const { return data.from("user_email", ""); }
 
@@ -77,9 +77,9 @@ struct WebConfig {
     }
 
     @property string domain(string shorthost) const { return flag("shorturl", "yes", "yes") ? shorthost : format("www.%s", shorthost); }
-    @property @nogc bool allowcgi() const nothrow { return flag("allowcgi",    "no", "yes"); }
+    @property @nogc bool allowcgi() const nothrow { return flag("allowcgi", "no", "yes"); }
     @property string localpath(in string localroot, in string path) const { return(format("%s%s", localroot, path)); }
-    @property @nogc bool redirect() const nothrow { return !flag("redirect",   "/",  "/"); }
+    @property @nogc bool redirect() const nothrow { return !flag("redirect", "/",  "/"); }
     @property @nogc bool redirectdir() const nothrow { return !flag("redirectdir","no", "no"); }
     @property string index() const { string to = data.from("redirect", "/"); if (to[0] != '/') { return(format("/%s", to)); } return(to); }
     @property string[] allowdirs() const nothrow { return(data.from("allowdirs", "/").split(",")); }
@@ -90,9 +90,7 @@ struct WebConfig {
       string p = path.startsWith(root) ? path : path.replace(localroot, root);
       if (p.length <= root.length) return true;
       string npath = p[root.length .. $];
-      foreach (d; allowdirs) {
-        if (indexOf(strip(npath), strip(d)) == 0) return true;
-      }
+      foreach (d; allowdirs) { if (indexOf(strip(npath), strip(d)) == 0) return true; }
       return false;
     }
 }
@@ -129,9 +127,9 @@ unittest {
   assert(noShort.domain("localhost") == "www.localhost", "shorturl=no must add www.");
 
   ServerConfig sc = ServerConfig("nonexistent.config");
-  assert(sc.maxClients()      == 2048,           "default maxClients must be 2048");
-  assert(sc.maxClientsPerIP() == 32,             "default maxClientsPerIP must be 32");
-  assert(sc.poolSize()        == 200,            "default poolSize must be 200");
+  assert(sc.maxClients()      == 2048, "default maxClients must be 2048");
+  assert(sc.maxClientsPerIP() == 32, "default maxClientsPerIP must be 32");
+  assert(sc.poolSize()        == 200, "default poolSize must be 200");
   assert(sc.serverInfo()      == "DaNode/0.0.3", "default serverInfo must be set");
 }
 

--- a/danode/webconfig.d
+++ b/danode/webconfig.d
@@ -46,8 +46,7 @@ struct ServerConfig {
     }
 
     T get(T)(string key, T def) { synchronized(serverConfigMutex) {
-      try { return to!T(data.from(key, to!string(def))); }
-      catch (Exception e) { return def; }
+      try { return to!T(data.from(key, to!string(def))); }catch (Exception e) { return def; }
     } }
 }
 
@@ -82,6 +81,8 @@ struct WebConfig {
     }
 }
 
+/* Returns a cached WebConfig for the given domain, reloading from disk if the file has been
+   modified since the last load. Enables hot-reload of per-domain web.config without restart. */
 WebConfig getConfig(ref WebConfig[string] configs, FilePayload fp, string key) {
   if (key !in configs || fp.mtime > configs[key].mtime) { configs[key] = WebConfig(fp); }
   return configs[key];

--- a/danode/workerpool.d
+++ b/danode/workerpool.d
@@ -8,22 +8,21 @@ import danode.interfaces : DriverInterface;
 import danode.router     : Router;
 import danode.log        : log, error, Level;
 
-immutable int MAX_CLIENTS = 2048;
-immutable int MAX_CLIENTS_PER_IP = 32;
-immutable int POOL_SIZE = 200;
+immutable int MAX_CLIENTS = 2048;         /// Maximum number of queued connections before dropping
+immutable int MAX_CLIENTS_PER_IP = 32;    /// Maximum concurrent connections per remote IP
+immutable int POOL_SIZE = 200;            /// Number of pre-allocated worker threads
 
 class WorkerPool {
   private:
-    Router            router;
-    Thread[]          workers;
-    DriverInterface[] queue;
-    Mutex             mutex;
-    Semaphore         sem;
-    bool              stopped;
+    Router            router;         /// Shared router instance passed to each Client
+    Thread[]          workers;        /// Fixed array of pre-allocated worker threads
+    Mutex             mutex;          /// Guards queue, stopped, and nAlivePerIP
+    DriverInterface[] queue;          /// Pending connection queue, protected by mutex
+    long[string]      nAlivePerIP;    /// Active connection count per remote IP, protected by mutex
+    bool              stopped;        /// Set to true on shutdown; workers exit their loop when seen
+    Semaphore         sem;            /// Counts pending items in queue; workers block on wait()
 
   public:
-    long[string]      nAlivePerIP;   // protected by mutex
-
     this(Router router) {
       this.router  = router;
       this.mutex   = new Mutex();
@@ -37,6 +36,8 @@ class WorkerPool {
       log(Level.Always, "WorkerPool started with %d threads", POOL_SIZE);
     }
 
+    /* Enqueue a new connection driver for handling by the next available worker.
+       Returns false if the connection should be rejected (rate limit or capacity exceeded). */
     bool push(DriverInterface driver, string ip, bool isLoopback) {
       synchronized(mutex) {
         if (!isLoopback && nAlivePerIP.get(ip, 0L) >= MAX_CLIENTS_PER_IP) return(false);
@@ -47,19 +48,25 @@ class WorkerPool {
       return true;
     }
 
-    @property long nAlive() { synchronized(mutex) { return nAlivePerIP.byValue.sum; } }
-    @property long queued() { synchronized(mutex) { return queue.length; } }
+    // Total number of connections currently being handled across all workers
+    @property long nAlive() { synchronized(mutex) { return(nAlivePerIP.byValue.sum); } }
+
+    // Number of connections waiting in the queue for a free worker
+    @property long queued() { synchronized(mutex) { return(queue.length); } }
+
+    // Trigger a filesystem rescan on the router (called by the server)
     void scan() { router.scan(); }
 
-
+    // Signal all workers to exit and join them
     void stop() {
-      synchronized(mutex) { stopped = true; }
+      synchronized(mutex) { if (stopped) { return; } stopped = true; }
       foreach (i; 0 .. POOL_SIZE) sem.notify();   // wake all workers to exit
       foreach (t; workers) t.join();
       log(Level.Always, "WorkerPool stopped");
     }
 
   private:
+    // Worker thread body: blocks on semaphore, dequeues one connection, runs it to completion.
     void workerLoop() {
       while (true) {
         sem.wait();
@@ -77,8 +84,8 @@ class WorkerPool {
         try {
           auto client = new Client(router, driver);
           client.run();
-        } catch(Exception e) { error("WorkerPool: client exception [%s]: %s", ip, e.msg);
-        } catch(Error e) { error("WorkerPool: client error [%s]: %s",     ip, e.msg); }
+        } catch(Exception e) { error("WorkerPool: Client exception [%s]: %s", ip, e.msg);
+        } catch(Error e) { error("WorkerPool: Client error [%s]: %s",     ip, e.msg); }
         synchronized(mutex) {
           if (ip in nAlivePerIP && nAlivePerIP[ip] > 0) nAlivePerIP[ip]--;
           if (nAlivePerIP[ip] == 0) nAlivePerIP.remove(ip);
@@ -86,3 +93,4 @@ class WorkerPool {
       }
     }
 }
+

--- a/danode/workerpool.d
+++ b/danode/workerpool.d
@@ -1,0 +1,88 @@
+/** danode/workerpool.d - Fixed thread pool: connection dispatch, per-IP tracking, worker lifecycle
+  * License: GPLv3 (https://github.com/DannyArends/DaNode) - Danny Arends **/
+module danode.workerpool;
+
+import danode.imports;
+import danode.client     : Client;
+import danode.interfaces : DriverInterface;
+import danode.router     : Router;
+import danode.log        : log, error, Level;
+
+immutable int MAX_CLIENTS = 2048;
+immutable int MAX_CLIENTS_PER_IP = 32;
+immutable int POOL_SIZE = 200;
+
+class WorkerPool {
+  private:
+    Router            router;
+    Thread[]          workers;
+    DriverInterface[] queue;
+    Mutex             mutex;
+    Semaphore         sem;
+    bool              stopped;
+
+  public:
+    long[string]      nAlivePerIP;   // protected by mutex
+
+    this(Router router) {
+      this.router  = router;
+      this.mutex   = new Mutex();
+      this.sem     = new Semaphore(0);
+      foreach (i; 0 .. POOL_SIZE) {
+        auto t = new Thread(&workerLoop, 256 * 1024);
+        t.isDaemon = true;
+        t.start();
+        workers ~= t;
+      }
+      log(Level.Always, "WorkerPool started with %d threads", POOL_SIZE);
+    }
+
+    bool push(DriverInterface driver, string ip, bool isLoopback) {
+      synchronized(mutex) {
+        if (!isLoopback && nAlivePerIP.get(ip, 0L) >= MAX_CLIENTS_PER_IP) return(false);
+        if (queue.length >= MAX_CLIENTS) return(false);
+        queue ~= driver;
+      }
+      sem.notify();
+      return true;
+    }
+
+    @property long nAlive() { synchronized(mutex) { return nAlivePerIP.byValue.sum; } }
+    @property long queued() { synchronized(mutex) { return queue.length; } }
+    void scan() { router.scan(); }
+
+
+    void stop() {
+      synchronized(mutex) { stopped = true; }
+      foreach (i; 0 .. POOL_SIZE) sem.notify();   // wake all workers to exit
+      foreach (t; workers) t.join();
+      log(Level.Always, "WorkerPool stopped");
+    }
+
+  private:
+    void workerLoop() {
+      while (true) {
+        sem.wait();
+
+        DriverInterface driver;
+        synchronized(mutex) {
+          if (stopped) return;
+          if (queue.length == 0) continue;   // spurious notify from stop()
+          driver = queue[0];
+          queue  = queue[1 .. $];
+        }
+
+        string ip = driver.ip;
+        synchronized(mutex) { nAlivePerIP[ip]++; }
+        try {
+          auto client = new Client(router, driver);
+          client.run();
+        } catch(Exception e) { error("WorkerPool: client exception [%s]: %s", ip, e.msg);
+        } catch(Error e) { error("WorkerPool: client error [%s]: %s",     ip, e.msg); }
+        synchronized(mutex) {
+          if (ip in nAlivePerIP && nAlivePerIP[ip] > 0) nAlivePerIP[ip]--;
+          if (nAlivePerIP[ip] == 0) nAlivePerIP.remove(ip);
+        }
+      }
+    }
+}

--- a/danode/workerpool.d
+++ b/danode/workerpool.d
@@ -57,7 +57,7 @@ class WorkerPool {
     // Signal all workers to exit and join them
     void stop() {
       synchronized(mutex) { if (stopped) { return; } stopped = true; }
-      foreach (i; 0 .. serverConfig.get("pool_size", 200)) sem.notify();   // wake all workers to exit
+      foreach (i; 0 .. workers.length) sem.notify();   // wake all workers to exit
       foreach (t; workers) t.join();
       log(Level.Trace, "WorkerPool stopped");
     }

--- a/danode/workerpool.d
+++ b/danode/workerpool.d
@@ -62,7 +62,7 @@ class WorkerPool {
       synchronized(mutex) { if (stopped) { return; } stopped = true; }
       foreach (i; 0 .. POOL_SIZE) sem.notify();   // wake all workers to exit
       foreach (t; workers) t.join();
-      log(Level.Always, "WorkerPool stopped");
+      log(Level.Trace, "WorkerPool stopped");
     }
 
   private:

--- a/danode/workerpool.d
+++ b/danode/workerpool.d
@@ -3,14 +3,11 @@
 module danode.workerpool;
 
 import danode.imports;
-import danode.client     : Client;
+import danode.client : Client;
 import danode.interfaces : DriverInterface;
-import danode.router     : Router;
-import danode.log        : log, error, Level;
-
-immutable int MAX_CLIENTS = 2048;         /// Maximum number of queued connections before dropping
-immutable int MAX_CLIENTS_PER_IP = 32;    /// Maximum concurrent connections per remote IP
-immutable int POOL_SIZE = 200;            /// Number of pre-allocated worker threads
+import danode.router : Router;
+import danode.log : log, error, Level;
+import danode.webconfig : serverConfig;
 
 class WorkerPool {
   private:
@@ -27,21 +24,21 @@ class WorkerPool {
       this.router  = router;
       this.mutex   = new Mutex();
       this.sem     = new Semaphore(0);
-      foreach (i; 0 .. POOL_SIZE) {
+      foreach (i; 0 .. serverConfig.get("pool_size", 200)) {
         auto t = new Thread(&workerLoop, 256 * 1024);
         t.isDaemon = true;
         t.start();
         workers ~= t;
       }
-      log(Level.Always, "WorkerPool started with %d threads", POOL_SIZE);
+      log(Level.Always, "WorkerPool started with %d threads", serverConfig.get("pool_size", 200));
     }
 
     /* Enqueue a new connection driver for handling by the next available worker.
        Returns false if the connection should be rejected (rate limit or capacity exceeded). */
     bool push(DriverInterface driver, string ip, bool isLoopback) {
       synchronized(mutex) {
-        if (!isLoopback && nAlivePerIP.get(ip, 0L) >= MAX_CLIENTS_PER_IP) return(false);
-        if (queue.length >= MAX_CLIENTS) return(false);
+        if (!isLoopback && nAlivePerIP.get(ip, 0L) >= serverConfig.get("max_clients_per_ip", 32)) return(false);
+        if (queue.length >= serverConfig.get("max_clients", 2048)) return(false);
         queue ~= driver;
       }
       sem.notify();
@@ -60,7 +57,7 @@ class WorkerPool {
     // Signal all workers to exit and join them
     void stop() {
       synchronized(mutex) { if (stopped) { return; } stopped = true; }
-      foreach (i; 0 .. POOL_SIZE) sem.notify();   // wake all workers to exit
+      foreach (i; 0 .. serverConfig.get("pool_size", 200)) sem.notify();   // wake all workers to exit
       foreach (t; workers) t.join();
       log(Level.Trace, "WorkerPool stopped");
     }

--- a/www/server.config
+++ b/www/server.config
@@ -1,7 +1,5 @@
-# workerpool.d
-MAX_CLIENTS = 2048
-MAX_CLIENTS_PER_IP = 32
-POOL_SIZE = 200
+# acme.d
+USER_EMAIL = Danny.Arends@gmail.com
 
 # client.d
 MAX_HEADER_SIZE = 32768
@@ -9,14 +7,21 @@ MAX_REQUEST_SIZE = 2097152
 MAX_UPLOAD_SIZE = 104857600
 MAX_SSE_TIME = 60000
 
-# process.d
-MAX_CGI_OUTPUT = 10485760
-
 # https.d
 HANDSHAKE_TIMEOUT = 5000
+
+# process.d
+MAX_CGI_OUTPUT = 10485760
+CGI_TIMEOUT = 4500
+
+# request.d
+REQUEST_TIMEOUT = 5000
 
 # response.d
 SERVERINFO = DaNode/0.0.3
 
-# acme.d
-USER_EMAIL = Danny.Arends@gmail.com
+# workerpool.d
+MAX_CLIENTS = 2048
+MAX_CLIENTS_PER_IP = 32
+POOL_SIZE = 200
+

--- a/www/server.config
+++ b/www/server.config
@@ -1,0 +1,22 @@
+# workerpool.d
+MAX_CLIENTS = 2048
+MAX_CLIENTS_PER_IP = 32
+POOL_SIZE = 200
+
+# client.d
+MAX_HEADER_SIZE = 32768
+MAX_REQUEST_SIZE = 2097152
+MAX_UPLOAD_SIZE = 104857600
+MAX_SSE_TIME = 60000
+
+# process.d
+MAX_CGI_OUTPUT = 10485760
+
+# https.d
+HANDSHAKE_TIMEOUT = 5000
+
+# response.d
+SERVERINFO = DaNode/0.0.3
+
+# acme.d
+USER_EMAIL = Danny.Arends@gmail.com

--- a/www/server.config
+++ b/www/server.config
@@ -1,27 +1,26 @@
 # acme.d
-USER_EMAIL = Danny.Arends@gmail.com
+user_email = Danny.Arends@gmail.com
 
 # client.d
-MAX_HEADER_SIZE = 32768
-MAX_REQUEST_SIZE = 2097152
-MAX_UPLOAD_SIZE = 104857600
-MAX_SSE_TIME = 60000
+max_header_size = 32768
+max_request_size = 2097152
+max_upload_size = 104857600
+max_sse_time = 60000
 
 # https.d
-HANDSHAKE_TIMEOUT = 5000
+handshake_timeout = 5000
 
 # process.d
-MAX_CGI_OUTPUT = 10485760
-CGI_TIMEOUT = 4500
+max_cgi_output = 10485760
+cgi_timeout = 4500
 
 # request.d
-REQUEST_TIMEOUT = 5000
+request_timeout = 5000
 
 # response.d
-SERVERINFO = DaNode/0.0.3
+serverinfo = DaNode/0.0.3
 
 # workerpool.d
-MAX_CLIENTS = 2048
-MAX_CLIENTS_PER_IP = 32
-POOL_SIZE = 200
-
+max_clients = 2048
+max_clients_per_ip = 32
+pool_size = 200


### PR DESCRIPTION
### Architecture

- Server no longer inherits Thread - accept loop runs on main thread, server.run() blocks directly
- Client no longer inherits Thread - connection handling is now a plain function call
- ClientInterface removed - only one implementor, interface was dead weight
- New WorkerPool - 200 pre-allocated threads replace unbounded per-connection thread spawning, fixing the VmSize growth that caused Error creating thread under load

### Security

- safePath - non-existent paths now check parent directory inside root, closing a symlink TOCTOU gap on shared hosting
- acme.d - hardcoded email replaced with serverConfig.get("user_email", "")

### Graceful shutdown

- SIGTERM and SIGINT handled in signals.d via shutdownSignal flag
- Server.alive() checks the flag - loop exits cleanly, pool drains, sockets close

### Configuration

- New www/server.config - all tunable constants (pool size, request limits, timeouts, server identity) now live in one file
- ServerConfig struct in webconfig.d shares the same string[string] parser as WebConfig
- Thread-safe get() method with mutex and fallback defaults
- All immutable constants removed from workerpool.d, client.d, process.d, https.d, response.d, acme.d

### Code cleanup

- parseKeyInput / keyoff removed
- stop() removed from Server - shutdown flows through run() → alive() → pool.stop()
- Error-response helpers moved from client.d to interfaces.d and renamed
- logConnection moved inside Client
- setLimit() moved into signals.d as setupPosix()
- imports.d - Semaphore added for WorkerPool

**Files added**: danode/workerpool.d, www/server.config